### PR TITLE
Quaternion refactor

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include metaworld/envs/assets *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include metaworld/envs/assets *
+recursive-include metaworld/envs/assets 

--- a/metaworld/envs/mujoco/sawyer_xyz/base.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/base.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from metaworld.core.serializable import Serializable
 from metaworld.envs.mujoco.mujoco_env import MujocoEnv
-from metaworld.envs.env_util import quat_to_zangle, zangle_to_quat, quat_create
+from metaworld.envs.env_util import quat_to_zangle, zangle_to_quat, quat_create, quat_mul
 
 
 OBS_TYPE = ['plain', 'with_goal_id', 'with_goal_and_id', 'with_goal', 'with_goal_init_obs']
@@ -122,8 +122,8 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
         action[3] = action[3] * self.action_rot_scale
         self.data.set_mocap_pos('mocap', new_mocap_pos)
         # replace this with learned rotation
-        quat = env_util.quat_mul(env_util.quat_create(np.array([0, 1., 0]), np.pi),
-                                 env_util.quat_create(np.array(rot_axis), action[3]))
+        quat = quat_mul(quat_create(np.array([0, 1., 0]), np.pi),
+                        quat_create(np.array(rot_axis), action[3]))
         self.data.set_mocap_quat('mocap', quat)
         # self.data.set_mocap_quat('mocap', np.array([np.cos(action[3]/2), np.sin(action[3]/2)*rot_axis[0], np.sin(action[3]/2)*rot_axis[1], np.sin(action[3]/2)*rot_axis[2]]))
         # self.data.set_mocap_quat('mocap', np.array([1, 0, 1, 0]))

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_assembly_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_assembly_peg.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -188,21 +188,7 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
             goal[:3]
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def reset_model(self):
         self._reset_hand()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -188,14 +188,7 @@ class SawyerBasketballEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_bin_picking.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_bin_picking.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -193,14 +193,7 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_box_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_box_close.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -188,21 +188,7 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def reset_model(self):
         self._reset_hand()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -177,14 +177,7 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -178,14 +178,7 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown_wall.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -177,14 +177,7 @@ class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_wall.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -178,14 +178,7 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_button.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_button.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -187,21 +187,7 @@ class SawyerCoffeeButtonEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_pull.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -187,21 +187,7 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_push.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -189,21 +189,7 @@ class SawyerCoffeePushEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_dial_turn.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_dial_turn.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 import pdb
 
@@ -194,14 +194,7 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
             goal[:3]
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_disassemble_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_disassemble_peg.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -186,21 +186,7 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
             goal[:3]
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def reset_model(self):
         self._reset_hand()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -194,14 +194,7 @@ class SawyerDoorEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_lock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_lock.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -196,14 +196,7 @@ class SawyerDoorLockEnv(SawyerXYZEnv):
             np.array([10., 10., 10.])
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_unlock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_unlock.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -195,14 +195,7 @@ class SawyerDoorUnlockEnv(SawyerXYZEnv):
             np.array([10., 10., 10.])
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_close.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -190,14 +190,7 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_open.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -196,14 +196,7 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_close.py
@@ -7,7 +7,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -196,14 +196,7 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
             np.array([10.0, 10.0, 10.0])
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_open.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -196,14 +196,7 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
             np.array([10.0, 10.0, 10.0])
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_hammer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_hammer.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -186,14 +186,7 @@ class SawyerHammerEnv(SawyerXYZEnv):
             objPos
         )
     
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_hammer_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_hand_insert.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_hand_insert.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -189,21 +189,7 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -176,14 +176,7 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press_side.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -177,14 +177,7 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -176,14 +176,7 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull_side.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -176,14 +176,7 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 import pdb
 
@@ -194,14 +194,7 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
             goal[:3]
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -186,14 +186,7 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_unplug_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_unplug_side.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -194,14 +194,7 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
             goal[:3]
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_and_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_and_place.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 
@@ -198,14 +198,7 @@ class SawyerPickAndPlaceEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_and_place_wsg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_and_place_wsg.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 class SawyerPickAndPlaceWsgEnv(SawyerXYZEnv):
@@ -171,14 +171,7 @@ class SawyerPickAndPlaceWsgEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_out_of_hole.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_out_of_hole.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -193,21 +193,7 @@ class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -189,14 +189,7 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -190,14 +190,7 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -189,14 +189,7 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
             objPos
         )  
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_side.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -189,14 +189,7 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_back.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -188,14 +188,7 @@ class SawyerPushBackEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -223,14 +223,7 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place_wall.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -218,14 +218,7 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -193,21 +193,7 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_remove.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_remove.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -206,14 +206,7 @@ class SawyerShelfRemoveEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_soccer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_soccer.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -187,21 +187,7 @@ class SawyerSoccerEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_pull.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -212,14 +212,7 @@ class SawyerStickPullEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_stick_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_push.py
@@ -7,7 +7,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -215,14 +215,7 @@ class SawyerStickPushEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_stick_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -193,14 +193,7 @@ class SawyerSweepEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_into_goal.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_into_goal.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -189,21 +189,7 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
-    def _set_obj_xyz(self, pos):
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
 
     def adjust_initObjPos(self, orig_init_pos):
         #This is to account for meshes for the geom and object are not aligned

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_tool.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_tool.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
 
@@ -217,14 +217,7 @@ class SawyerSweepToolEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -198,14 +198,7 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
             objPos
         )
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open.py
@@ -8,7 +8,7 @@ from metaworld.envs.env_util import get_stat_in_paths, \
 from metaworld.core.multitask_env import MultitaskEnv
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
-from pyquaternion import Quaternion
+
 from metaworld.envs.mujoco.utils.rotation import euler2quat
 
 from metaworld.envs.mujoco.sawyer_xyz.base import OBS_TYPE
@@ -200,14 +200,7 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
         )
     
 
-    def _set_obj_xyz_quat(self, pos, angle):
-        quat = Quaternion(axis = [0,0,1], angle = angle).elements
-        qpos = self.data.qpos.flat.copy()
-        qvel = self.data.qvel.flat.copy()
-        qpos[9:12] = pos.copy()
-        qpos[12:16] = quat.copy()
-        qvel[9:15] = 0
-        self.set_state(qpos, qvel)
+
 
 
     def _set_obj_xyz(self, pos):

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ extras['dev'] = [
 setup(
     name='metaworld',
     packages=find_packages(),
+    include_package_data=True,
     install_requires=required,
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,7 @@ required = [
     # Please keep alphabetized
     'gym==0.12.1',
     'mujoco-py<2.1,>=2.0',
-    'numpy-stl>=2.10.1',
     'opencv-python>=4.1.0.25',
-    'pyquaternion==0.9.5',
 ]
 
 
@@ -18,6 +16,7 @@ extras['dev'] = [
     # Please keep alphabetized
     'ipdb',
     'pylint',
+    'pyquaternion==0.9.5',
     'pytest>=3.6',
 ]
 

--- a/tests/metaworld/envs/test_quat.py
+++ b/tests/metaworld/envs/test_quat.py
@@ -1,0 +1,73 @@
+import pytest
+import numpy as np
+
+from pyquaternion import Quaternion
+import metaworld.envs.env_util as env_util
+
+def quat_to_zangle_old(quat):
+    angle = (Quaternion(axis = [0,1,0], angle = (np.pi/2)).inverse * Quaternion(quat)).angle
+    return angle
+    
+def zangle_to_quat_old(zangle):
+    """
+    :param zangle in rad
+    :return: quaternion
+    """
+    return (Quaternion(axis = [0,1,0], angle = (np.pi/2)) * Quaternion(axis=[-1, 0, 0], angle= zangle)).elements
+
+def random_axis():
+    bases = [[0, 0, 1], [0, 1, 0], [1, 0, 0],
+             [0, 0, -1], [0, -1, 0], [-1, 0, 0]]
+    axis_idx = np.random.randint(len(bases))
+    return np.array(bases[axis_idx], dtype='float')
+
+def random_angle():
+    return np.random.rand()*2*np.pi - np.pi
+
+def assert_close(q1, q2, tol=1e-6):
+    diff = q1 - q2
+    max_diff = np.abs(diff).max()
+    if max_diff > tol:
+        msg = 'Quaternions differ by {}, q1={}, q2={}'.format(max_diff, q1, q2)
+        raise AssertionError(msg)
+
+def test_quaternions():
+        
+    num_samps = 1000
+    for k in range(num_samps):
+
+        # test construction from axis+angle
+        ax1 = random_axis()
+        ang1 = random_angle()
+
+        q11 = Quaternion(axis=ax1, angle=ang1)
+        q12 = env_util.quat_create(ax1, ang1)
+
+        assert_close(q11.elements, q12)
+
+        # test multiplication
+        ax2 = random_axis()
+        ang2 = random_angle()
+        q21 = Quaternion(axis=ax2, angle=ang2)
+        q22 = env_util.quat_create(ax2, ang2)
+
+        prod1 = q11 * q21
+        prod2 = env_util.quat_mul(q12, q22)
+        
+        assert_close(prod1.elements, prod2)
+
+        # test inversion
+        assert_close(q11.inverse.elements, env_util.quat_inv(q12))
+        assert_close(q21.inverse.elements, env_util.quat_inv(q22))
+
+        # test conversion to angle
+        exp_ang = quat_to_zangle_old(q12)
+        ang = env_util.quat_to_zangle(q12)
+        assert np.abs(exp_ang - ang) < 1e-6, "exp_ang={}, ang={}".format(exp_ang, ang)
+
+        # test conversion from angle
+        exp_q = zangle_to_quat_old(ang1)
+        q = env_util.zangle_to_quat(ang1)
+        assert_close(exp_q, q)
+
+test_quaternions()

--- a/tests/metaworld/envs/test_quat.py
+++ b/tests/metaworld/envs/test_quat.py
@@ -69,5 +69,3 @@ def test_quaternions():
         exp_q = zangle_to_quat_old(ang1)
         q = env_util.zangle_to_quat(ang1)
         assert_close(exp_q, q)
-
-test_quaternions()


### PR DESCRIPTION
Refactored quaternion code to use MuJoCo quaternion functions instead of pyquaternion.	

- Refactored redundant functions in sawyer_xyz/sawyer_*	tasks into sawyer_xyz/base.py.
- Swapped pyquaternion functionality in env_utils.py to use MuJoCo quaternion functions.
- Created unit test (test_quat.py) to demonstrate parity between MuJoCo	functions and pyquaternion functions.
- Removed pyquaternion dependency in setup.py from production, added to dev.
- Removed numpy-stl dependency in setup.py.
- metaworld/envs/assets directory was not copied during installation in Linux or Mac. Added MANIFEST.in file to include assets on installation, and added install_package_data=True to setup.py to fix this.
