### PR TITLE
Fix excessive memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,8 @@ dmypy.json
 .pyre/
 
 
-# garage-specific stuff below this line
+# metaworld-specific stuff below this line
+MUJOCO_LOG.TXT
 
 # Other IDEs and editors
 *.sublime-project

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ test: RUN_CMD = pytest -v
 test: run
 	@echo "Running test suite..."
 
+check-memory:  ## Profile memory usage
+check-memory: RUN_CMD = scripts/profile_memory_usage.py
+check-memory: run
+	@echo "Profiling memory usage..."
+
 ci-job:
 	pytest -n $$(nproc) --cov=metaworld -v
 	coverage xml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY setup.py /root/code/metaworld/setup.py
 WORKDIR /root/code/metaworld
 
 # Install metaworld dependencies
-RUN pip install -e .[all,dev]
+RUN pip install -e .[dev]
 
 # Add code stub last
 COPY . /root/code/metaworld

--- a/metaworld/envs/assets/multi_object_sawyer_xyz/door_config.xml
+++ b/metaworld/envs/assets/multi_object_sawyer_xyz/door_config.xml
@@ -32,7 +32,6 @@ Usage:
     </visual>
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ" meshdir="../meshes/sawyer"/>
-    <size njmax="6000" nconmax="6000"/>
     <option
             gravity="0 0 -9.81"
             iterations="50"

--- a/metaworld/envs/assets/multi_object_sawyer_xyz/door_hook_config.xml
+++ b/metaworld/envs/assets/multi_object_sawyer_xyz/door_hook_config.xml
@@ -32,7 +32,6 @@ Usage:
     </visual>
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ" meshdir="../meshes/sawyer"/>
-    <size njmax="6000" nconmax="6000"/>
     <option
             gravity="0 0 -9.81"
             iterations="50"

--- a/metaworld/envs/assets/multi_object_sawyer_xyz/sawyer_multiobj.xml
+++ b/metaworld/envs/assets/multi_object_sawyer_xyz/sawyer_multiobj.xml
@@ -4,7 +4,6 @@
     <!-- <option impratio="0.01" /> -->
     <!-- <option collision="predefined" /> -->
     <option integrator="Euler" timestep="0.002" iterations="50"/>
-    <size njmax="2000" nconmax="1000" />
     <asset>
         <mesh name="pedestal" file="pedestal.stl" />
         <mesh name="base" file="base.stl" />

--- a/metaworld/envs/assets/multi_object_sawyer_xyz/sawyer_reach_torque.xml
+++ b/metaworld/envs/assets/multi_object_sawyer_xyz/sawyer_reach_torque.xml
@@ -4,7 +4,6 @@
     <!-- <option impratio="0.01" /> -->
     <!-- <option collision="predefined" /> -->
     <option integrator="Euler" timestep="0.002" iterations="50"/>
-    <size njmax="500" nconmax="100" />
     <asset>
         <mesh name="pedestal" file="pedestal.stl" />
         <mesh name="base" file="base.stl" />

--- a/metaworld/envs/assets/multi_object_sawyer_xyz/shared_config.xml
+++ b/metaworld/envs/assets/multi_object_sawyer_xyz/shared_config.xml
@@ -35,7 +35,6 @@ Usage:
     </visual>
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ" meshdir="../meshes/sawyer"/>
-    <size njmax="6000" nconmax="6000"/>
     <option
             gravity="0 0 -9.81"
             iterations="200"

--- a/metaworld/envs/assets/multiobject_models/cartgripper.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_getflows.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_getflows.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_grasp.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_grasp.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ"/>
-    <size njmax="6000" nconmax="6000"/>
     <option timestep="0.005" gravity="0 0 -9.81" iterations="50" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_noautogen.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_noautogen.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_updown.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_updown.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="2000"/>
     <option timestep="0.005" gravity="0 0 -9.81" iterations="50" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_updown_2cam.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_updown_2cam.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ"/>
-    <size njmax="2000" nconmax="2000"/>
     <option timestep="0.005" gravity="0 0 -9.81" iterations="50" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_updown_2cam_noautogen.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_updown_2cam_noautogen.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ"/>
-    <size njmax="2000" nconmax="2000"/>
     <option timestep="0.005" gravity="0 0 -9.81" iterations="50" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_updown_rot.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_updown_rot.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="2000"/>
     <option timestep="0.005" gravity="0 0 -9.81" iterations="50" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/cartgripper_updown_whitefingers.xml
+++ b/metaworld/envs/assets/multiobject_models/cartgripper_updown_whitefingers.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="2000"/>
     <option timestep="0.005" gravity="0 0 -9.81" iterations="50" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/pushing2d.xml
+++ b/metaworld/envs/assets/multiobject_models/pushing2d.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/pushing2d_controller.xml
+++ b/metaworld/envs/assets/multiobject_models/pushing2d_controller.xml
@@ -1,6 +1,5 @@
 <mujoco model="pushing2d">
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/pushing2d_controller_nomarkers.xml
+++ b/metaworld/envs/assets/multiobject_models/pushing2d_controller_nomarkers.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/pushing2d_controller_touchsensor.xml
+++ b/metaworld/envs/assets/multiobject_models/pushing2d_controller_touchsensor.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/pushing2d_controller_touchsensor_nomarkers.xml
+++ b/metaworld/envs/assets/multiobject_models/pushing2d_controller_touchsensor_nomarkers.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/pushing2d_touch.xml
+++ b/metaworld/envs/assets/multiobject_models/pushing2d_touch.xml
@@ -1,7 +1,6 @@
 <mujoco model="pushing2d">
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" />
-    <size njmax="2000" nconmax="500"/>
     <option timestep="0.01" gravity="0 0 -9.81" iterations="20" integrator="Euler" />
     <default>
         <joint limited="false" damping="1" />

--- a/metaworld/envs/assets/multiobject_models/sawyer_assets/sawyer_xyz/shared_config.xml
+++ b/metaworld/envs/assets/multiobject_models/sawyer_assets/sawyer_xyz/shared_config.xml
@@ -35,7 +35,6 @@ Usage:
     </visual>
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ" meshdir="../meshes/sawyer"/>
-    <size njmax="6000" nconmax="6000"/>
     <option
             gravity="0 0 -9.81"
             iterations="200"

--- a/metaworld/envs/assets/sawyer_xyz/door_config.xml
+++ b/metaworld/envs/assets/sawyer_xyz/door_config.xml
@@ -36,7 +36,6 @@ Usage:
     </visual>
 
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ" meshdir="../meshes/sawyer"/>
-    <size njmax="6000" nconmax="6000"/>
     <option
             gravity="0 0 -9.81"
             iterations="50"

--- a/metaworld/envs/assets/sawyer_xyz/sawyer_push_and_reach_mocap_goal_hidden.xml
+++ b/metaworld/envs/assets/sawyer_xyz/sawyer_push_and_reach_mocap_goal_hidden.xml
@@ -4,7 +4,6 @@
     <!-- <option impratio="0.01" /> -->
     <!-- <option collision="predefined" /> -->
     <option integrator="Euler" timestep="0.002" iterations="50"/>
-    <size njmax="500" nconmax="100" />
     <asset>
         <mesh name="pedestal" file="pedestal.stl" />
         <mesh name="base" file="base.stl" />

--- a/metaworld/envs/assets/sawyer_xyz/shared_config.xml
+++ b/metaworld/envs/assets/sawyer_xyz/shared_config.xml
@@ -77,10 +77,8 @@ Usage:
         <headlight ambient="0.5 0.5 0.5"  />
     </visual>
 
-    <!-- <compiler angle="radian" meshdir="../meshes/sawyer"/>
-    <size njmax="500" nconmax="100"/> -->
+    <!-- <compiler angle="radian" meshdir="../meshes/sawyer"/> -->
     <compiler inertiafromgeom="auto" angle="radian" coordinate="local" eulerseq="XYZ" meshdir="../meshes" texturedir="../textures"/>
-    <size njmax="6000" nconmax="6000"/>
     <!-- <option
             iterations="50"
             integrator="Euler"

--- a/metaworld/envs/mujoco/dynamic_mjc/rope.py
+++ b/metaworld/envs/mujoco/dynamic_mjc/rope.py
@@ -24,7 +24,7 @@ def rope(num_beads = 5,
                              eulerseq="XYZ",
                              meshdir=os.path.dirname(os.path.realpath(__file__)) + "/../../assets/meshes",
                              texturedir=os.path.dirname(os.path.realpath(__file__)) + "/../../assets/textures")
-    mjcmodel.root.size(njmax="6000", nconmax="6000")
+    # mjcmodel.root.size(njmax="6000", nconmax="6000")
     mjcmodel.root.option(timestep='0.0025', iterations="50", tolerance="1e-10", solver="Newton", jacobian="dense", cone="elliptic")
     default = mjcmodel.root.default()
     default.joint(limited="true",

--- a/scripts/profile_memory_usage.py
+++ b/scripts/profile_memory_usage.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Test script for profiling average memory footprint."""
+import pprint
+
+import memory_profiler
+
+from metaworld.envs.mujoco.sawyer_xyz.env_lists import HARD_MODE_LIST
+from tests.helpers import step_env
+
+
+def build_and_step(env_cls):
+    env = env_cls()
+    env.reset()
+    step_env(env, max_path_length=1000, iterations=10)
+    return env
+
+def build_and_step_all(classes):
+    envs = []
+    for env_cls in classes:
+        env = build_and_step(env_cls)
+        envs += [env]
+
+def profile_hard_mode_indepedent():
+    profile = {}
+    for env_cls in HARD_MODE_LIST:
+        target = (build_and_step, [env_cls], {})
+        memory_usage = memory_profiler.memory_usage(target)
+        profile[env_cls] = max(memory_usage)
+
+    return profile
+
+def profile_hard_mode_shared():
+    target = (build_and_step_all, [HARD_MODE_LIST], {})
+    usage = memory_profiler.memory_usage(target)
+    return max(usage)
+
+
+if __name__ == '__main__':
+    profile = profile_hard_mode_indepedent()
+    print('--------- Independent memory footprints ---------')
+    for cls, u in profile.items():
+        print('{:<40} {:>5.1f} MB'.format(cls.__name__, u))
+    max_independent = max(profile.values())
+    mean_independent = sum(profile.values()) / len(profile)
+    min_independent = min(profile.values())
+    print('\nSummary:')
+    print('| min      | mean     | max      |')
+    print('|----------|----------|----------|')
+    print('| {:.1f} MB | {:.1f} MB | {:.1f} MB |'
+          .format(min_independent, mean_independent, max_independent))
+    print('\n')
+
+    print('---------    Shared memory footprint    ---------')
+    max_usage = profile_hard_mode_shared()
+    mean_shared = max_usage / len(HARD_MODE_LIST)
+    print('Mean memory footprint (n = {}): {:.1f} MB'
+          .format(len(HARD_MODE_LIST), mean_shared))

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ extras = dict()
 extras['dev'] = [
     # Please keep alphabetized
     'ipdb',
+    'memory_profiler',
     'pylint',
     'pyquaternion==0.9.5',
     'pytest>=3.6',

--- a/tests/integration/test_memory_usage.py
+++ b/tests/integration/test_memory_usage.py
@@ -1,0 +1,44 @@
+import gym
+import memory_profiler
+import pytest
+
+from metaworld.envs.mujoco.sawyer_xyz.env_lists import HARD_MODE_LIST
+from tests.helpers import step_env
+
+
+def build_and_step(env_cls):
+    env = env_cls()
+    step_env(env, max_path_length=1000, iterations=10)
+    return env
+
+def build_and_step_all(classes):
+    envs = []
+    for env_cls in classes:
+        env = build_and_step(env_cls)
+        envs += [env]
+
+@pytest.fixture(scope='module')
+def hard_mode_usage():
+    profile = {}
+    for env_cls in HARD_MODE_LIST:
+        target = (build_and_step, [env_cls], {})
+        memory_usage = memory_profiler.memory_usage(target)
+        profile[env_cls] = max(memory_usage)
+
+    return profile
+
+@pytest.mark.parametrize('env_cls', HARD_MODE_LIST)
+def test_max_memory_usage(env_cls, hard_mode_usage):
+    # No env should use more  than 100MB
+    #
+    # Note: this is quite a bit higher than the average usage cap, because
+    # loading a single environment incurs a fixed memory overhead which can't
+    # be shared among environment in the same process
+    assert hard_mode_usage[env_cls] < 250
+
+def test_avg_memory_usage():
+    # average usage no greater than 60MB/env
+    target = (build_and_step_all, [HARD_MODE_LIST], {})
+    usage = memory_profiler.memory_usage(target)
+    average = max(usage) / len(HARD_MODE_LIST)
+    assert average < 60


### PR DESCRIPTION
This PR fixes the excessive memory usage reported in #11. The root
cause was over-allocation of memory in the MuJoCo engine, because
our models specified extremely-conservative static values for njmax and
nconmax.

MuJoCo can infer appropriate values directly from the model file, so I
removed those parameters entirely from all models.

I also added an integration test which profiles the memory usage of
each environment (and all environments together) and fails if it is too
high. You can run it with `make check-memory` or by executing
`scripts/profile_memory_usage.py`

The output of `make check-memory` looks like this:
```
--------- Independent memory footprints ---------
SawyerReachPushPickPlaceEnv              207.6 MB
SawyerReachPushPickPlaceWallEnv          214.2 MB
SawyerDoorEnv                            213.5 MB
SawyerDoorCloseEnv                       190.1 MB
SawyerDrawerOpenEnv                      207.8 MB
SawyerDrawerCloseEnv                     213.3 MB
SawyerButtonPressTopdownEnv              217.1 MB
SawyerButtonPressEnv                     217.1 MB
SawyerButtonPressTopdownWallEnv          220.1 MB
SawyerButtonPressWallEnv                 225.0 MB
SawyerPegInsertionSideEnv                204.1 MB
SawyerPegUnplugSideEnv                   218.5 MB
SawyerWindowOpenEnv                      218.3 MB
SawyerWindowCloseEnv                     220.8 MB
SawyerNutDisassembleEnv                  208.4 MB
SawyerHammerEnv                          214.8 MB
SawyerPlateSlideEnv                      223.8 MB
SawyerPlateSlideSideEnv                  216.4 MB
SawyerPlateSlideBackEnv                  212.8 MB
SawyerPlateSlideBackSideEnv              218.3 MB
SawyerHandlePressEnv                     205.8 MB
SawyerHandlePullEnv                      215.0 MB
SawyerHandlePressSideEnv                 206.7 MB
SawyerHandlePullSideEnv                  216.4 MB
SawyerStickPushEnv                       204.2 MB
SawyerStickPullEnv                       214.6 MB
SawyerBasketballEnv                      215.2 MB
SawyerSoccerEnv                          191.6 MB
SawyerFaucetOpenEnv                      215.8 MB
SawyerFaucetCloseEnv                     191.6 MB
SawyerCoffeePushEnv                      212.4 MB
SawyerCoffeePullEnv                      217.9 MB
SawyerCoffeeButtonEnv                    193.8 MB
SawyerSweepEnv                           217.8 MB
SawyerSweepIntoGoalEnv                   219.9 MB
SawyerPickOutOfHoleEnv                   219.7 MB
SawyerNutAssemblyEnv                     211.4 MB
SawyerShelfPlaceEnv                      216.9 MB
SawyerPushBackEnv                        216.9 MB
SawyerLeverPullEnv                       217.2 MB
SawyerDialTurnEnv                        205.3 MB
SawyerBinPickingEnv                      215.4 MB
SawyerBoxCloseEnv                        202.6 MB
SawyerHandInsertEnv                      211.3 MB
SawyerDoorLockEnv                        216.8 MB
SawyerDoorUnlockEnv                      214.7 MB

Summary:
| min      | mean     | max      |
|----------|----------|----------|
| 190.1 MB | 212.4 MB | 225.0 MB |

---------    Shared memory footprint    ---------
Mean memory footprint (n = 50): 51.5 MB
```

Fixes #11