### PR TITLE
Fix missing assets after pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include metaworld/envs/assets 
+recursive-include metaworld/envs/assets * 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include metaworld/envs/assets * 
+graft metaworld/envs/assets 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ __Table of Contents__
 - [Acknowledgements](#acknowledgements)
 
 ## Installation
-Meta-World is based on MuJoCo, which has a proprietary dependency we can't set up for you. Please follow the [instructions](https://github.com/openai/mujoco-py#install-mujoco) in the mujoco-py package for help. Once you're ready to install everything, clone this repository and install:
+Meta-World is based on MuJoCo, which has a proprietary dependency we can't set up for you. Please follow the [instructions](https://github.com/openai/mujoco-py#install-mujoco) in the mujoco-py package for help. Once you're ready to install everything, run:
+
+```
+pip install git+https://github.com/rlworkgroup/metaworld.git@master
+```
+
+Alternatively, you can clone the repository and install an editable version locally:
 
 ```
 git clone https://github.com/rlworkgroup/metaworld.git

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ __Table of Contents__
 Meta-World is based on MuJoCo, which has a proprietary dependency we can't set up for you. Please follow the [instructions](https://github.com/openai/mujoco-py#install-mujoco) in the mujoco-py package for help. Once you're ready to install everything, run:
 
 ```
-pip install git+https://github.com/rlworkgroup/metaworld.git@master
+pip install git+https://github.com/rlworkgroup/metaworld.git@master#egg=metaworld
 ```
 
 Alternatively, you can clone the repository and install an editable version locally:


### PR DESCRIPTION
Currently, the `pip install` does not copy over the assets in the final distribution and leads to the following error

Minimum example to reproduce
```python
from metaworld.benchmarks import ML1
env = ML1.get_train_tasks('pick-place-v1')
```

Error log
```
Traceback (most recent call last):
  File "meta.py", line 2, in <module>
    env = ML1.get_train_tasks('pick-place-v1')
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/benchmarks/ml1.py", line 41, in get_train_tasks
    return cls(task_name, env_type='train', n_goals=50, sample_all=sample_all)
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/benchmarks/ml1.py", line 27, in __init__
    sample_all=sample_all)
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/envs/mujoco/multitask_env.py", line 109, in __init_
_
    task_env = env_cls(*task_args, **task_kwargs)
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place
.py", line 45, in __init__
    **kwargs
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/envs/mujoco/sawyer_xyz/base.py", line 80, in __init__
    super().__init__(*args, **kwargs)
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/envs/mujoco/sawyer_xyz/base.py", line 26, in __init__
    MujocoEnv.__init__(self, model_name, frame_skip=frame_skip)
  File "/miniconda3/envs/lib/python3.7/site-packages/metaworld/envs/mujoco/mujoco_env.py", line 29, in __init__
    raise IOError("File %s does not exist" % fullpath)
OSError: File /miniconda3/envs/lib/python3.7/site-packages/metaworld/envs/assets/sawyer_xyz/sawyer_reach_push_pick_and_place.xml does not exist
```

Essentially, the `assets` folder was not being copied over due to a missing directive in the `MANIFEST.in`. 

I've also updated the instructions to directly install from pip without cloning.