### PR TITLE
Fix ML1 goal consistency across pickling

### DIFF
--- a/metaworld/benchmarks/__init__.py
+++ b/metaworld/benchmarks/__init__.py
@@ -1,9 +1,11 @@
 from metaworld.benchmarks.ml1 import ML1
 from metaworld.benchmarks.ml1_with_pinned_goal import ML1WithPinnedGoal
 from metaworld.benchmarks.ml10 import ML10
+from metaworld.benchmarks.ml10_with_pinned_goal import ML10WithPinnedGoal
 from metaworld.benchmarks.ml45 import ML45
 from metaworld.benchmarks.mt10 import MT10
 from metaworld.benchmarks.mt50 import MT50
 
 
-__all__ = ['ML1', 'ML1WithPinnedGoal', 'ML10', 'ML45', 'MT10', 'MT50']
+__all__ = ['ML1', 'ML1WithPinnedGoal', 'ML10', 'ML10WithPinnedGoal',
+           'ML45', 'MT10', 'MT50']

--- a/metaworld/benchmarks/__init__.py
+++ b/metaworld/benchmarks/__init__.py
@@ -3,9 +3,10 @@ from metaworld.benchmarks.ml1_with_pinned_goal import ML1WithPinnedGoal
 from metaworld.benchmarks.ml10 import ML10
 from metaworld.benchmarks.ml10_with_pinned_goal import ML10WithPinnedGoal
 from metaworld.benchmarks.ml45 import ML45
+from metaworld.benchmarks.ml45_with_pinned_goal import ML45WithPinnedGoal
 from metaworld.benchmarks.mt10 import MT10
 from metaworld.benchmarks.mt50 import MT50
 
 
 __all__ = ['ML1', 'ML1WithPinnedGoal', 'ML10', 'ML10WithPinnedGoal',
-           'ML45', 'MT10', 'MT50']
+           'ML45', 'ML45WithPinnedGoal', 'MT10', 'MT50']

--- a/metaworld/benchmarks/__init__.py
+++ b/metaworld/benchmarks/__init__.py
@@ -1,8 +1,9 @@
 from metaworld.benchmarks.ml1 import ML1
+from metaworld.benchmarks.ml1_with_pinned_goal import ML1WithPinnedGoal
 from metaworld.benchmarks.ml10 import ML10
 from metaworld.benchmarks.ml45 import ML45
 from metaworld.benchmarks.mt10 import MT10
 from metaworld.benchmarks.mt50 import MT50
 
 
-__all__ = ['ML1', 'ML10', 'ML45', 'MT10', 'MT50']
+__all__ = ['ML1', 'ML1WithPinnedGoal', 'ML10', 'ML45', 'MT10', 'MT50']

--- a/metaworld/benchmarks/ml10_with_pinned_goal.py
+++ b/metaworld/benchmarks/ml10_with_pinned_goal.py
@@ -1,0 +1,23 @@
+from metaworld.benchmarks import ML10
+
+class ML10WithPinnedGoal(ML10):
+    """A wrapper of ML1 environment that retains goals across pickling and unpickling.
+
+    `env = ML1.get_train_tasks('task-name')` gives an environment that internally keeps 50 pre-generated variants of
+    this task, and `env.sample_task(1)` will return one of these variants. However, these variants cannot survive
+    pickling. That is, `pickle.loads(pickle.dumps(env))` will give an environment with a new set of variants, which is
+    not desired when doing vectorized and parallel sampling. This wrapper solves this caveat by saving and restoring
+    the parameter of a variant, i.e. the goal of the task, explicitly.
+
+    See discussion at https://github.com/rlworkgroup/metaworld/issues/24#issuecomment-576996005
+
+    """
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        state['goals'] = self._discrete_goals
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self.discretize_goal_space(state.get('goals', {}))

--- a/metaworld/benchmarks/ml1_with_pinned_goal.py
+++ b/metaworld/benchmarks/ml1_with_pinned_goal.py
@@ -1,0 +1,23 @@
+from metaworld.benchmarks import ML1
+
+class ML1WithPinnedGoal(ML1):
+    """A wrapper of ML1 environment that retains goals across pickling and unpickling.
+
+    `env = ML1.get_train_tasks('task-name')` gives an environment that internally keeps 50 pre-generated variants of
+    this task, and `env.sample_task(1)` will return one of these variants. However, these variants cannot survive
+    pickling. That is, `pickle.loads(pickle.dumps(env))` will give an environment with a new set of variants, which is
+    not desired when doing vectorized and parallel sampling. This wrapper solves this caveat by saving and restoring
+    the parameter of a variant, i.e. the goal of the task, explicitly.
+
+    See discussion at https://github.com/rlworkgroup/metaworld/issues/24#issuecomment-576996005
+
+    """
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        state['goals'] = self._discrete_goals
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self.discretize_goal_space(state.get('goals', {}))

--- a/metaworld/benchmarks/ml45_with_pinned_goal.py
+++ b/metaworld/benchmarks/ml45_with_pinned_goal.py
@@ -1,0 +1,23 @@
+from metaworld.benchmarks import ML45
+
+class ML45WithPinnedGoal(ML45):
+    """A wrapper of ML1 environment that retains goals across pickling and unpickling.
+
+    `env = ML1.get_train_tasks('task-name')` gives an environment that internally keeps 50 pre-generated variants of
+    this task, and `env.sample_task(1)` will return one of these variants. However, these variants cannot survive
+    pickling. That is, `pickle.loads(pickle.dumps(env))` will give an environment with a new set of variants, which is
+    not desired when doing vectorized and parallel sampling. This wrapper solves this caveat by saving and restoring
+    the parameter of a variant, i.e. the goal of the task, explicitly.
+
+    See discussion at https://github.com/rlworkgroup/metaworld/issues/24#issuecomment-576996005
+
+    """
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        state['goals'] = self._discrete_goals
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self.discretize_goal_space(state.get('goals', {}))

--- a/tests/metaworld/benchmarks/test_ml1_with_pinned_goals.py
+++ b/tests/metaworld/benchmarks/test_ml1_with_pinned_goals.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pickle
+import pytest
+
+from metaworld.benchmarks import ML1WithPinnedGoal
+
+
+@pytest.mark.parametrize('task_name', ML1WithPinnedGoal.available_tasks())
+def test_ml1_with_pinned_goal(task_name):
+    env = ML1WithPinnedGoal(task_name)
+    num_variants = len(env._discrete_goals)
+    tasks = env.sample_tasks(num_variants)
+
+    def get_goals():
+        goals = []
+        for task in tasks:
+            env.set_task(task)
+            obs = env.reset()
+            action = env.action_space.sample()
+            obs, reward, done, info = env.step(action)
+            goals.append(info['goal'])
+        return goals
+
+    goals1 = get_goals()
+    env = pickle.loads(pickle.dumps(env))
+    goals2 = get_goals()
+
+    assert np.array_equal(goals1, goals2)
+
+

--- a/tests/metaworld/benchmarks/test_pinned_goals.py
+++ b/tests/metaworld/benchmarks/test_pinned_goals.py
@@ -2,7 +2,7 @@ import numpy as np
 import pickle
 import pytest
 
-from metaworld.benchmarks import ML1WithPinnedGoal
+from metaworld.benchmarks import ML1WithPinnedGoal, ML10WithPinnedGoal
 
 
 @pytest.mark.parametrize('task_name', ML1WithPinnedGoal.available_tasks())
@@ -27,4 +27,24 @@ def test_ml1_with_pinned_goal(task_name):
 
     assert np.array_equal(goals1, goals2)
 
+def test_ml10_with_pinned_goal():
+    env = ML10WithPinnedGoal()
+    num_variants = len(env._discrete_goals)
+    tasks = env.sample_tasks(num_variants)
+
+    def get_goals():
+        goals = []
+        for task in tasks:
+            env.set_task(task)
+            obs = env.reset()
+            action = env.action_space.sample()
+            obs, reward, done, info = env.step(action)
+            goals.append(info['goal'])
+        return goals
+
+    goals1 = get_goals()
+    env = pickle.loads(pickle.dumps(env))
+    goals2 = get_goals()
+
+    assert np.array_equal(goals1, goals2)
 


### PR DESCRIPTION
This PR adds `ML1WithPinnedGoal`. This is a wrapper of ML1 environment that retains goals across pickling and unpickling.

See discussion at https://github.com/rlworkgroup/metaworld/issues/24#issuecomment-576996005