### PR TITLE
Fix missing one hot encoding in MultiClassMTEnv

### DIFF
--- a/metaworld/envs/mujoco/multitask_env.py
+++ b/metaworld/envs/mujoco/multitask_env.py
@@ -230,7 +230,7 @@ class MultiClassMultiTaskEnv(MultiTaskEnv):
             return tasks
 
     def step(self, action):
-        obs, reward, done, info = self.active_env.step(action)
+        obs, reward, done, info = super().step(action)
         obs = self._augment_observation(obs)
         if 'task_type' in dir(self.active_env):
             name = '{}-{}'.format(str(self.active_env.__class__.__name__), self.active_env.task_type)


### PR DESCRIPTION
In MultiClassMultiTaskEnv, when `step` is called, the one hot encoding of the active env was not included in the returned `infos` dict. This PR addresses this issue by adding the one hot encoding to the returned env_info.

- By inheriting the parent class's step function
  the one hot encoding of the environment is included
  in the env_infos