### PR TITLE
Add the option to set a fixed seed when sampling goals in ML1.

### DIFF
--- a/metaworld/benchmarks/ml1.py
+++ b/metaworld/benchmarks/ml1.py
@@ -6,7 +6,7 @@ from metaworld.envs.mujoco.env_dict import HARD_MODE_ARGS_KWARGS, HARD_MODE_CLS_
 
 class ML1(MultiClassMultiTaskEnv, Benchmark, Serializable):
 
-    def __init__(self, task_name, env_type='train', n_goals=50, sample_all=False):
+    def __init__(self, task_name, env_type='train', n_goals=50, sample_all=False, goal_seed=None):
         assert env_type == 'train' or env_type == 'test'
         Serializable.quick_init(self, locals())
         
@@ -27,6 +27,8 @@ class ML1(MultiClassMultiTaskEnv, Benchmark, Serializable):
             obs_type='plain',
             sample_all=sample_all)
 
+        if goal_seed is not None:
+            self.active_env.goal_space.seed(goal_seed)
         goals = self.active_env.sample_goals_(n_goals)
         self.discretize_goal_space({task_name: goals})
 
@@ -38,9 +40,11 @@ class ML1(MultiClassMultiTaskEnv, Benchmark, Serializable):
         return tasks
 
     @classmethod
-    def get_train_tasks(cls, task_name, sample_all=False):
-        return cls(task_name, env_type='train', n_goals=50, sample_all=sample_all)
+    def get_train_tasks(cls, task_name, sample_all=False, goal_seed=None):
+        return cls(task_name, env_type='train', n_goals=50, sample_all=sample_all,
+                   goal_seed=goal_seed)
     
     @classmethod
-    def get_test_tasks(cls, task_name, sample_all=False):
-        return cls(task_name, env_type='test', n_goals=10, sample_all=sample_all)
+    def get_test_tasks(cls, task_name, sample_all=False, goal_seed=None):
+        return cls(task_name, env_type='test', n_goals=10, sample_all=sample_all,
+                   goal_seed=goal_seed)


### PR DESCRIPTION
This option allows one to use distributed actors while maintaining a fixed set of train/test goals.