### PR TITLE
Expose names of all available tasks

### DIFF
--- a/metaworld/envs/mujoco/multitask_env.py
+++ b/metaworld/envs/mujoco/multitask_env.py
@@ -125,6 +125,11 @@ class MultiClassMultiTaskEnv(MultiTaskEnv):
         self._active_task = 0
         self._check_env_list()
 
+    @property
+    def all_task_names(self):
+        """list[str]: Name of all available tasks. Note that two envs of a task can have different goals."""
+        return self._task_names
+
     def discretize_goal_space(self, discrete_goals):
         for task, goals in discrete_goals.items():
             if task in self._task_names:
@@ -229,11 +234,7 @@ class MultiClassMultiTaskEnv(MultiTaskEnv):
     def step(self, action):
         obs, reward, done, info = super().step(action)
         obs = self._augment_observation(obs)
-        if 'task_type' in dir(self.active_env):
-            name = '{}-{}'.format(str(self.active_env.__class__.__name__), self.active_env.task_type)
-        else:
-            name = str(self.active_env.__class__.__name__)
-        info['task_name'] = name
+        info['task_name'] = self._task_names[self._active_task]
         return obs, reward, done, info
 
     def _augment_observation(self, obs):

--- a/tests/metaworld/envs/test_multitask_env.py
+++ b/tests/metaworld/envs/test_multitask_env.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 
+from metaworld.benchmarks import ML10
 from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_CLS_DICT, MEDIUM_MODE_ARGS_KWARGS
 from metaworld.envs.mujoco.multitask_env import MultiClassMultiTaskEnv
 from metaworld.envs.mujoco.sawyer_xyz import SawyerReachPushPickPlaceEnv
@@ -213,3 +214,12 @@ def test_ml3():
             _ = multi_task_env.reset()
             goal = multi_task_env.active_env.goal
             assert multi_task_env.active_env.goal_space.contains(goal)
+
+
+def test_task_name():
+    task_names = MEDIUM_MODE_CLS_DICT['test'].keys()
+    env = ML10.get_test_tasks()
+    assert sorted(env.all_task_names) == sorted(task_names)
+
+    _, _, _, info = env.step(env.action_space.sample())
+    assert info['task_name'] in task_names


### PR DESCRIPTION
This change is to improve the readability of task name.

* return the name of a task as it is designated in env_dict.py
* add `all_task_names()` that returns names of all available tasks.