### PR TITLE
Remove tags from registered envs

### DIFF
--- a/metaworld/envs/mujoco/__init__.py
+++ b/metaworld/envs/mujoco/__init__.py
@@ -21,11 +21,8 @@ def register_custom_envs():
 
     register(
         id='SawyerReachXYEnv-v1',
-        entry_point='metaworld.envs.mujoco.sawyer_xyz.sawyer_reach:SawyerReachXYEnv',
-        tags={
-            'git-commit-hash': '2d95c75',
-            'author': 'murtaza'
-        },
+        entry_point=('metaworld.envs.mujoco.sawyer_xyz.sawyer_reach:'
+                     'SawyerReachXYEnv'),
         kwargs={
             'hide_goal_markers': True,
             'norm_order': 2,
@@ -34,11 +31,8 @@ def register_custom_envs():
 
     register(
         id='SawyerReachXYZEnv-v0',
-        entry_point='metaworld.envs.mujoco.sawyer_xyz.sawyer_reach:SawyerReachXYZEnv',
-        tags={
-            'git-commit-hash': '7b3113b',
-            'author': 'vitchyr'
-        },
+        entry_point=('metaworld.envs.mujoco.sawyer_xyz.sawyer_reach:'
+                     'SawyerReachXYZEnv'),
         kwargs={
             'hide_goal_markers': False,
             'norm_order': 2,
@@ -47,11 +41,8 @@ def register_custom_envs():
 
     register(
         id='SawyerReachXYZEnv-v1',
-        entry_point='metaworld.envs.mujoco.sawyer_xyz.sawyer_reach:SawyerReachXYZEnv',
-        tags={
-            'git-commit-hash': 'bea5de',
-            'author': 'murtaza'
-        },
+        entry_point=('metaworld.envs.mujoco.sawyer_xyz.sawyer_reach:'
+                     'SawyerReachXYZEnv'),
         kwargs={
             'hide_goal_markers': True,
             'norm_order': 2,
@@ -61,20 +52,11 @@ def register_custom_envs():
     register(
         id='Image48SawyerReachXYEnv-v1',
         entry_point=create_image_48_sawyer_reach_xy_env_v1,
-        tags={
-            'git-commit-hash': '2d95c75',
-            'author': 'murtaza'
-        },
     )
     register(
         id='Image84SawyerReachXYEnv-v1',
         entry_point=create_image_84_sawyer_reach_xy_env_v1,
-        tags={
-            'git-commit-hash': '2d95c75',
-            'author': 'murtaza'
-        },
     )
-
 
     """
     Pushing Tasks, XY
@@ -84,10 +66,6 @@ def register_custom_envs():
         id='SawyerPushAndReachEnvEasy-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': 'ddd73dc',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.15, 0.4, 0.02, -.1, .45),
             goal_high=(0.15, 0.7, 0.02, .1, .65),
@@ -107,10 +85,6 @@ def register_custom_envs():
         id='SawyerPushAndReachEnvMedium-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': 'ddd73dc',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.2, 0.35, 0.02, -.15, .4),
             goal_high=(0.2, 0.75, 0.02, .15, .7),
@@ -130,10 +104,6 @@ def register_custom_envs():
         id='SawyerPushAndReachEnvHard-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': 'ddd73dc',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.25, 0.3, 0.02, -.2, .35),
             goal_high=(0.25, 0.8, 0.02, .2, .75),
@@ -156,10 +126,6 @@ def register_custom_envs():
         id='SawyerPushAndReachArenaEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': 'dea1627',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.25, 0.3, 0.02, -.2, .4),
             goal_high=(0.25, 0.875, 0.02, .2, .8),
@@ -178,10 +144,6 @@ def register_custom_envs():
         id='SawyerPushAndReachArenaResetFreeEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': 'dea1627',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.25, 0.3, 0.02, -.2, .4),
             goal_high=(0.25, 0.875, 0.02, .2, .8),
@@ -200,10 +162,6 @@ def register_custom_envs():
         id='SawyerPushAndReachSmallArenaEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': '7256aaf',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.15, 0.4, 0.02, -.1, .5),
             goal_high=(0.15, 0.75, 0.02, .1, .7),
@@ -223,10 +181,6 @@ def register_custom_envs():
         id='SawyerPushAndReachSmallArenaResetFreeEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_and_reach_env:SawyerPushAndReachXYEnv',
-        tags={
-            'git-commit-hash': '7256aaf',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.15, 0.4, 0.02, -.1, .5),
             goal_high=(0.15, 0.75, 0.02, .1, .7),
@@ -249,10 +203,6 @@ def register_custom_envs():
         id='SawyerPushNIPS-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_nips:SawyerPushAndReachXYEasyEnv',
-        tags={
-            'git-commit-hash': 'bede25d',
-            'author': 'ashvin',
-        },
         kwargs=dict(
             hide_goal=True,
             reward_info=dict(
@@ -266,10 +216,6 @@ def register_custom_envs():
         id='SawyerPushNIPSHarder-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_push_nips:SawyerPushAndReachXYHarderEnv',
-        tags={
-            'git-commit-hash': 'b5cac93',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             hide_goal=True,
             reward_info=dict(
@@ -287,11 +233,7 @@ def register_custom_envs():
         id='SawyerDoorHookEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_door_hook:SawyerDoorHookEnv',
-        tags={
-            'git-commit-hash': '15b48d5',
-            'author': 'murtaza',
-        },
-        kwargs = dict(
+        kwargs=dict(
             goal_low=(-0.1, 0.45, 0.1, 0),
             goal_high=(0.05, 0.65, .25, .83),
             hand_low=(-0.1, 0.45, 0.1),
@@ -307,10 +249,6 @@ def register_custom_envs():
         id='SawyerDoorHookResetFreeEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_door_hook:SawyerDoorHookEnv',
-        tags={
-            'git-commit-hash': '15b48d5',
-            'author': 'murtaza',
-        },
         kwargs=dict(
             goal_low=(-0.1, 0.45, 0.1, 0),
             goal_high=(0.05, 0.65, .25, .83),
@@ -330,10 +268,6 @@ def register_custom_envs():
         id='SawyerPickupEnv-v0',
         entry_point='metaworld.envs.mujoco.sawyer_xyz'
                     '.sawyer_pick_and_place:SawyerPickAndPlaceEnv',
-        tags={
-            'git-commit-hash': '30f23f7',
-            'author': 'steven',
-        },
         kwargs=dict(
             hand_low=(-0.1, 0.55, 0.05),
             hand_high=(0.0, 0.65, 0.2),
@@ -348,11 +282,8 @@ def register_custom_envs():
 
     register(
         id='SawyerShelfXYZEnv-v1',
-        entry_point='metaworld.envs.mujoco.sawyer_xyz.sawyer_shelf_remove:SawyerShelfRemoveEnv',
-        tags={
-            'git-commit-hash': 'beafc10b3b18b6553bfd3722f76c2095100528ac',
-            'author': 'brandon'
-        },
+        entry_point=('metaworld.envs.mujoco.sawyer_xyz.sawyer_shelf_remove:'
+                     'SawyerShelfRemoveEnv'),
         kwargs={
         },
     )
@@ -360,10 +291,6 @@ def register_custom_envs():
     register(
         id='Image48SawyerShelfXYZEnv-v1',
         entry_point=create_image_48_sawyer_shelf_xy_env_v1,
-        tags={
-            'git-commit-hash': 'beafc10b3b18b6553bfd3722f76c2095100528ac',
-            'author': 'brandon'
-        },
     )
 
 
@@ -408,6 +335,7 @@ def create_image_84_sawyer_reach_xy_env_v1():
         normalize=True,
     )
 
+
 def create_image_48_sawyer_push_and_reach_arena_env_v0():
     from metaworld.core.image_env import ImageEnv
     from metaworld.envs.mujoco.cameras import sawyer_pusher_camera_upright_v2
@@ -421,6 +349,7 @@ def create_image_48_sawyer_push_and_reach_arena_env_v0():
         normalize=True,
     )
 
+
 def create_image_48_sawyer_push_and_reach_arena_env_reset_free_v0():
     from metaworld.core.image_env import ImageEnv
     from metaworld.envs.mujoco.cameras import sawyer_pusher_camera_upright_v2
@@ -433,5 +362,6 @@ def create_image_48_sawyer_push_and_reach_arena_env_reset_free_v0():
         transpose=True,
         normalize=True,
     )
+
 
 register_custom_envs()


### PR DESCRIPTION
The newest version of gym that installs with metaworld no longer has a tags field when environments are registered using the gym registration function.

We may need to pin the current version of gym and also remove the global registration of gym environments, but those things will be addressed in later PRs. @ryanjulian any input?