### PR TITLE
Static task ids

### DIFF
--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place import SawyerReachPushPickPlaceEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_hand_insert import SawyerHandInsertEnv
@@ -17,7 +16,6 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_close import SawyerDrawerClo
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_box_close import SawyerBoxCloseEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_insertion_side import SawyerPegInsertionSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_bin_picking import SawyerBinPickingEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_close import SawyerDrawerCloseEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_box_close import SawyerBoxCloseEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_push import SawyerStickPushEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_pull import SawyerStickPullEnv
@@ -52,21 +50,72 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back import SawyerPlate
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_side import SawyerPlateSlideSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side import SawyerPlateSlideBackSideEnv
 
+_NUM_METAWORLD_ENVS = 50
+_static_task_ids = {
+    'reach-v1': 0,
+    'push-v1': 1,
+    'pick-place-v1': 2,
+    'reach-wall-v1': 3,
+    'pick-place-wall-v1': 4,
+    'push-wall-v1': 5,
+    'door-open-v1': 6,
+    'door-close-v1': 7,
+    'drawer-open-v1': 8,
+    'drawer-close-v1': 9,
+    'button-press-topdown-v1': 10,
+    'button-press-v1': 11,
+    'button-press-topdown-wall-v1': 12,
+    'button-press-wall-v1': 13,
+    'peg-insert-side-v1': 14,
+    'peg-unplug-side-v1': 15,
+    'window-open-v1': 16,
+    'window-close-v1': 17,
+    'dissassemble-v1': 18,
+    'hammer-v1': 19,
+    'plate-slide-v1': 20,
+    'plate-slide-side-v1': 21,
+    'plate-slide-back-v1': 22,
+    'plate-slide-back-side-v1': 23,
+    'handle-press-v1': 24,
+    'handle-pull-v1': 25,
+    'handle-press-side-v1': 26,
+    'handle-pull-side-v1': 27,
+    'stick-push-v1': 28,
+    'stick-pull-v1': 29,
+    'basket-ball-v1': 30,
+    'soccer-v1': 31,
+    'faucet-open-v1': 32,
+    'faucet-close-v1': 33,
+    'coffee-push-v1': 34,
+    'coffee-pull-v1': 35,
+    'coffee-button-v1': 36,
+    'sweep-v1': 37,
+    'sweep-into-v1': 38,
+    'pick-out-of-hole-v1': 39,
+    'assembly-v1': 40,
+    'shelf-place-v1': 41,
+    'push-back-v1': 42,
+    'lever-pull-v1': 43,
+    'dial-turn-v1': 44,
+    'bin-picking-v1': 45,
+    'box-close-v1': 46,
+    'hand-insert-v1': 47,
+    'door-lock-v1': 48,
+    'door-unlock-v1': 49,
+}
 
-EASY_MODE_CLS_DICT= {
+EASY_MODE_CLS_DICT = {
     'reach-v1': SawyerReachPushPickPlaceEnv,
     'push-v1': SawyerReachPushPickPlaceEnv,
     'pick-place-v1': SawyerReachPushPickPlaceEnv,
-    'door-v1': SawyerDoorEnv,
+    'door-open-v1': SawyerDoorEnv,
     'drawer-open-v1': SawyerDrawerOpenEnv,
     'drawer-close-v1': SawyerDrawerCloseEnv,
     'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
-    'ped-insert-side-v1': SawyerPegInsertionSideEnv,
+    'peg-insert-side-v1': SawyerPegInsertionSideEnv,
     'window-open-v1': SawyerWindowOpenEnv,
     'window-close-v1': SawyerWindowCloseEnv,
 }
-
-
 '''
     MT10 environments and arguments.
     Example usage:
@@ -87,13 +136,16 @@ EASY_MODE_CLS_DICT= {
         env.discretize_goal_space(goals_dict)
 '''
 EASY_MODE_ARGS_KWARGS = {
-    key: dict(args=[], kwargs={'obs_type': 'plain'})
+    key: dict(args=[],
+              kwargs={
+                  'obs_type': 'plain',
+                  'task_id': _static_task_ids[key]
+              })
     for key, _ in EASY_MODE_CLS_DICT.items()
 }
 EASY_MODE_ARGS_KWARGS['reach-v1']['kwargs']['task_type'] = 'reach'
 EASY_MODE_ARGS_KWARGS['push-v1']['kwargs']['task_type'] = 'push'
 EASY_MODE_ARGS_KWARGS['pick-place-v1']['kwargs']['task_type'] = 'pick_place'
-
 '''
     ML10 environments and arguments
     Example usage for meta-training:
@@ -111,29 +163,30 @@ EASY_MODE_ARGS_KWARGS['pick-place-v1']['kwargs']['task_type'] = 'pick_place'
         )
 '''
 
-MEDIUM_MODE_CLS_DICT = dict(
-    train={
-        'reach-v1': SawyerReachPushPickPlaceEnv,
-        'push-v1': SawyerReachPushPickPlaceEnv,
-        'pick-place-v1': SawyerReachPushPickPlaceEnv,
-        'door-v1': SawyerDoorEnv,
-        'drawer-close-v1': SawyerDrawerCloseEnv,
-        'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
-        'ped-insert-side-v1': SawyerPegInsertionSideEnv,
-        'window-open-v1': SawyerWindowOpenEnv,
-        'sweep-v1': SawyerSweepEnv,
-        'basketball-v1': SawyerBasketballEnv,
-    },
-    test={
-        'drawer-open-v1': SawyerDrawerOpenEnv,
-        'door-close-v1': SawyerDoorCloseEnv,
-        'shelf-place-v1': SawyerShelfPlaceEnv,
-        'sweep-into-v1': SawyerSweepIntoGoalEnv,
-        'lever-pull-v1': SawyerLeverPullEnv,
-    }
-)
+MEDIUM_MODE_CLS_DICT = dict(train={
+    'reach-v1': SawyerReachPushPickPlaceEnv,
+    'push-v1': SawyerReachPushPickPlaceEnv,
+    'pick-place-v1': SawyerReachPushPickPlaceEnv,
+    'door-open-v1': SawyerDoorEnv,
+    'drawer-close-v1': SawyerDrawerCloseEnv,
+    'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
+    'peg-insert-side-v1': SawyerPegInsertionSideEnv,
+    'window-open-v1': SawyerWindowOpenEnv,
+    'sweep-v1': SawyerSweepEnv,
+    'basketball-v1': SawyerBasketballEnv,
+},
+                            test={
+                                'drawer-open-v1': SawyerDrawerOpenEnv,
+                                'door-close-v1': SawyerDoorCloseEnv,
+                                'shelf-place-v1': SawyerShelfPlaceEnv,
+                                'sweep-into-v1': SawyerSweepIntoGoalEnv,
+                                'lever-pull-v1': SawyerLeverPullEnv,
+                            })
 medium_mode_train_args_kwargs = {
-    key: dict(args=[], kwargs={'obs_type': 'plain', 'random_init': True})
+    key: dict(args=[], kwargs={
+        'obs_type': 'plain',
+        'random_init': True
+    })
     for key, _ in MEDIUM_MODE_CLS_DICT['train'].items()
 }
 
@@ -144,14 +197,13 @@ medium_mode_test_args_kwargs = {
 
 medium_mode_train_args_kwargs['reach-v1']['kwargs']['task_type'] = 'reach'
 medium_mode_train_args_kwargs['push-v1']['kwargs']['task_type'] = 'push'
-medium_mode_train_args_kwargs['pick-place-v1']['kwargs']['task_type'] = 'pick_place'
+medium_mode_train_args_kwargs['pick-place-v1']['kwargs'][
+    'task_type'] = 'pick_place'
 
 MEDIUM_MODE_ARGS_KWARGS = dict(
     train=medium_mode_train_args_kwargs,
     test=medium_mode_test_args_kwargs,
 )
-
-
 '''
     ML45 environments and arguments
 '''
@@ -167,7 +219,7 @@ HARD_MODE_CLS_DICT = dict(
         'door-close-v1': SawyerDoorCloseEnv,
         'drawer-open-v1': SawyerDrawerOpenEnv,
         'drawer-close-v1': SawyerDrawerCloseEnv,
-        'button-press_topdown-v1': SawyerButtonPressTopdownEnv,
+        'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
         'button-press-v1': SawyerButtonPressEnv,
         'button-press-topdown-wall-v1': SawyerButtonPressTopdownWallEnv,
         'button-press-wall-v1': SawyerButtonPressWallEnv,
@@ -179,7 +231,7 @@ HARD_MODE_CLS_DICT = dict(
         'hammer-v1': SawyerHammerEnv,
         'plate-slide-v1': SawyerPlateSlideEnv,
         'plate-slide-side-v1': SawyerPlateSlideSideEnv,
-        'plate-slide-back-v1': SawyerPlateSlideBackEnv, 
+        'plate-slide-back-v1': SawyerPlateSlideBackEnv,
         'plate-slide-back-side-v1': SawyerPlateSlideBackSideEnv,
         'handle-press-v1': SawyerHandlePressEnv,
         'handle-pull-v1': SawyerHandlePullEnv,
@@ -201,13 +253,15 @@ HARD_MODE_CLS_DICT = dict(
         'shelf-place-v1': SawyerShelfPlaceEnv,
         'push-back-v1': SawyerPushBackEnv,
         'lever-pull-v1': SawyerLeverPullEnv,
-        'dial-turn-v1': SawyerDialTurnEnv,},
+        'dial-turn-v1': SawyerDialTurnEnv,
+    },
     test={
         'bin-picking-v1': SawyerBinPickingEnv,
         'box-close-v1': SawyerBoxCloseEnv,
         'hand-insert-v1': SawyerHandInsertEnv,
         'door-lock-v1': SawyerDoorLockEnv,
-        'door-unlock-v1': SawyerDoorUnlockEnv,},
+        'door-unlock-v1': SawyerDoorUnlockEnv,
+    },
 )
 
 

--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -173,7 +173,7 @@ MEDIUM_MODE_CLS_DICT = dict(train={
     'peg-insert-side-v1': SawyerPegInsertionSideEnv,
     'window-open-v1': SawyerWindowOpenEnv,
     'sweep-v1': SawyerSweepEnv,
-    'basketball-v1': SawyerBasketballEnv,
+    'basket-ball-v1': SawyerBasketballEnv,
 },
                             test={
                                 'drawer-open-v1': SawyerDrawerOpenEnv,
@@ -185,13 +185,14 @@ MEDIUM_MODE_CLS_DICT = dict(train={
 medium_mode_train_args_kwargs = {
     key: dict(args=[], kwargs={
         'obs_type': 'plain',
-        'random_init': True
+        'random_init': True,
+        'task_id' : _static_task_ids[key],
     })
     for key, _ in MEDIUM_MODE_CLS_DICT['train'].items()
 }
 
 medium_mode_test_args_kwargs = {
-    key: dict(args=[], kwargs={'obs_type': 'plain'})
+    key: dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : _static_task_ids[key]})
     for key, _ in MEDIUM_MODE_CLS_DICT['test'].items()
 }
 
@@ -266,7 +267,7 @@ HARD_MODE_CLS_DICT = dict(
 
 
 def _hard_mode_args_kwargs(env_cls, key):
-    kwargs = dict(random_init=True, obs_type='plain')
+    kwargs = dict(random_init=True, obs_type='plain', task_id=_static_task_ids[key])
     if key == 'reach-v1' or key == 'reach-wall-v1':
         kwargs['task_type'] = 'reach'
     elif key == 'push-v1' or key == 'push-wall-v1':

--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import numpy as np
 
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place import SawyerReachPushPickPlaceEnv
@@ -50,72 +52,74 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back import SawyerPlate
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_side import SawyerPlateSlideSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side import SawyerPlateSlideBackSideEnv
 
-_NUM_METAWORLD_ENVS = 50
-_static_task_ids = {
-    'reach-v1': 0,
-    'push-v1': 1,
-    'pick-place-v1': 2,
-    'reach-wall-v1': 3,
-    'pick-place-wall-v1': 4,
-    'push-wall-v1': 5,
-    'door-open-v1': 6,
-    'door-close-v1': 7,
-    'drawer-open-v1': 8,
-    'drawer-close-v1': 9,
-    'button-press-topdown-v1': 10,
-    'button-press-v1': 11,
-    'button-press-topdown-wall-v1': 12,
-    'button-press-wall-v1': 13,
-    'peg-insert-side-v1': 14,
-    'peg-unplug-side-v1': 15,
-    'window-open-v1': 16,
-    'window-close-v1': 17,
-    'dissassemble-v1': 18,
-    'hammer-v1': 19,
-    'plate-slide-v1': 20,
-    'plate-slide-side-v1': 21,
-    'plate-slide-back-v1': 22,
-    'plate-slide-back-side-v1': 23,
-    'handle-press-v1': 24,
-    'handle-pull-v1': 25,
-    'handle-press-side-v1': 26,
-    'handle-pull-side-v1': 27,
-    'stick-push-v1': 28,
-    'stick-pull-v1': 29,
-    'basket-ball-v1': 30,
-    'soccer-v1': 31,
-    'faucet-open-v1': 32,
-    'faucet-close-v1': 33,
-    'coffee-push-v1': 34,
-    'coffee-pull-v1': 35,
-    'coffee-button-v1': 36,
-    'sweep-v1': 37,
-    'sweep-into-v1': 38,
-    'pick-out-of-hole-v1': 39,
-    'assembly-v1': 40,
-    'shelf-place-v1': 41,
-    'push-back-v1': 42,
-    'lever-pull-v1': 43,
-    'dial-turn-v1': 44,
-    'bin-picking-v1': 45,
-    'box-close-v1': 46,
-    'hand-insert-v1': 47,
-    'door-lock-v1': 48,
-    'door-unlock-v1': 49,
-}
+ALL_ENVIRONMENTS = OrderedDict((
+    ('reach-v1', SawyerReachPushPickPlaceEnv),
+    ('push-v1', SawyerReachPushPickPlaceEnv),
+    ('pick-place-v1', SawyerReachPushPickPlaceEnv),
+    ('reach-wall-v1', SawyerReachPushPickPlaceWallEnv),
+    ('pick-place-wall-v1', SawyerReachPushPickPlaceWallEnv),
+    ('push-wall-v1', SawyerReachPushPickPlaceWallEnv),
+    ('door-open-v1', SawyerDoorEnv),
+    ('door-close-v1', SawyerDoorCloseEnv),
+    ('drawer-open-v1', SawyerDrawerOpenEnv),
+    ('drawer-close-v1', SawyerDrawerCloseEnv),
+    ('button-press-topdown-v1', SawyerButtonPressTopdownEnv),
+    ('button-press-v1', SawyerButtonPressEnv),
+    ('button-press-topdown-wall-v1', SawyerButtonPressTopdownWallEnv),
+    ('button-press-wall-v1', SawyerButtonPressWallEnv),
+    ('peg-insert-side-v1', SawyerPegInsertionSideEnv),
+    ('peg-unplug-side-v1', SawyerPegUnplugSideEnv),
+    ('window-open-v1', SawyerWindowOpenEnv),
+    ('window-close-v1', SawyerWindowCloseEnv),
+    ('dissassemble-v1', SawyerNutDisassembleEnv),
+    ('hammer-v1', SawyerHammerEnv),
+    ('plate-slide-v1', SawyerPlateSlideEnv),
+    ('plate-slide-side-v1', SawyerPlateSlideSideEnv),
+    ('plate-slide-back-v1', SawyerPlateSlideBackEnv),
+    ('plate-slide-back-side-v1', SawyerPlateSlideBackSideEnv),
+    ('handle-press-v1', SawyerHandlePressEnv),
+    ('handle-pull-v1', SawyerHandlePullEnv),
+    ('handle-press-side-v1', SawyerHandlePressSideEnv),
+    ('handle-pull-side-v1', SawyerHandlePullSideEnv),
+    ('stick-push-v1', SawyerStickPushEnv),
+    ('stick-pull-v1', SawyerStickPullEnv),
+    ('basketball-v1', SawyerBasketballEnv),
+    ('soccer-v1', SawyerSoccerEnv),
+    ('faucet-open-v1', SawyerFaucetOpenEnv),
+    ('faucet-close-v1', SawyerFaucetCloseEnv),
+    ('coffee-push-v1', SawyerCoffeePushEnv),
+    ('coffee-pull-v1', SawyerCoffeePullEnv),
+    ('coffee-button-v1', SawyerCoffeeButtonEnv),
+    ('sweep-v1', SawyerSweepEnv),
+    ('sweep-into-v1', SawyerSweepIntoGoalEnv),
+    ('pick-out-of-hole-v1', SawyerPickOutOfHoleEnv),
+    ('assembly-v1', SawyerNutAssemblyEnv),
+    ('shelf-place-v1', SawyerShelfPlaceEnv),
+    ('push-back-v1', SawyerPushBackEnv),
+    ('lever-pull-v1', SawyerLeverPullEnv),
+    ('dial-turn-v1', SawyerDialTurnEnv),
+    ('bin-picking-v1', SawyerBinPickingEnv),
+    ('box-close-v1', SawyerBoxCloseEnv),
+    ('hand-insert-v1', SawyerHandInsertEnv),
+    ('door-lock-v1', SawyerDoorLockEnv),
+    ('door-unlock-v1', SawyerDoorUnlockEnv)))
 
-EASY_MODE_CLS_DICT = {
-    'reach-v1': SawyerReachPushPickPlaceEnv,
-    'push-v1': SawyerReachPushPickPlaceEnv,
-    'pick-place-v1': SawyerReachPushPickPlaceEnv,
-    'door-open-v1': SawyerDoorEnv,
-    'drawer-open-v1': SawyerDrawerOpenEnv,
-    'drawer-close-v1': SawyerDrawerCloseEnv,
-    'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
-    'peg-insert-side-v1': SawyerPegInsertionSideEnv,
-    'window-open-v1': SawyerWindowOpenEnv,
-    'window-close-v1': SawyerWindowCloseEnv,
-}
+_NUM_METAWORLD_ENVS = len(ALL_ENVIRONMENTS)
+
+EASY_MODE_CLS_DICT = OrderedDict((
+    ('reach-v1', SawyerReachPushPickPlaceEnv),
+    ('push-v1', SawyerReachPushPickPlaceEnv),
+    ('pick-place-v1', SawyerReachPushPickPlaceEnv),
+    ('door-open-v1', SawyerDoorEnv),
+    ('drawer-open-v1', SawyerDrawerOpenEnv),
+    ('drawer-close-v1', SawyerDrawerCloseEnv),
+    ('button-press-topdown-v1', SawyerButtonPressTopdownEnv),
+    ('peg-insert-side-v1', SawyerPegInsertionSideEnv),
+    ('window-open-v1', SawyerWindowOpenEnv),
+    ('window-close-v1', SawyerWindowCloseEnv))
+)
+    
+
 '''
     MT10 environments and arguments.
     Example usage:
@@ -139,7 +143,7 @@ EASY_MODE_ARGS_KWARGS = {
     key: dict(args=[],
               kwargs={
                   'obs_type': 'plain',
-                  'task_id': _static_task_ids[key]
+                  'task_id': list(ALL_ENVIRONMENTS.keys()).index(key)
               })
     for key, _ in EASY_MODE_CLS_DICT.items()
 }
@@ -163,36 +167,40 @@ EASY_MODE_ARGS_KWARGS['pick-place-v1']['kwargs']['task_type'] = 'pick_place'
         )
 '''
 
-MEDIUM_MODE_CLS_DICT = dict(train={
-    'reach-v1': SawyerReachPushPickPlaceEnv,
-    'push-v1': SawyerReachPushPickPlaceEnv,
-    'pick-place-v1': SawyerReachPushPickPlaceEnv,
-    'door-open-v1': SawyerDoorEnv,
-    'drawer-close-v1': SawyerDrawerCloseEnv,
-    'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
-    'peg-insert-side-v1': SawyerPegInsertionSideEnv,
-    'window-open-v1': SawyerWindowOpenEnv,
-    'sweep-v1': SawyerSweepEnv,
-    'basket-ball-v1': SawyerBasketballEnv,
-},
-                            test={
-                                'drawer-open-v1': SawyerDrawerOpenEnv,
-                                'door-close-v1': SawyerDoorCloseEnv,
-                                'shelf-place-v1': SawyerShelfPlaceEnv,
-                                'sweep-into-v1': SawyerSweepIntoGoalEnv,
-                                'lever-pull-v1': SawyerLeverPullEnv,
-                            })
+MEDIUM_MODE_CLS_DICT = OrderedDict((
+    ('train', 
+        OrderedDict((
+            ('reach-v1', SawyerReachPushPickPlaceEnv),
+            ('push-v1', SawyerReachPushPickPlaceEnv),
+            ('pick-place-v1', SawyerReachPushPickPlaceEnv),
+            ('door-open-v1', SawyerDoorEnv),
+            ('drawer-close-v1', SawyerDrawerCloseEnv),
+            ('button-press-topdown-v1', SawyerButtonPressTopdownEnv),
+            ('peg-insert-side-v1', SawyerPegInsertionSideEnv),
+            ('window-open-v1', SawyerWindowOpenEnv),
+            ('sweep-v1', SawyerSweepEnv),
+            ('basketball-v1', SawyerBasketballEnv)))
+    ),
+    ('test', 
+        OrderedDict((
+            ('drawer-open-v1', SawyerDrawerOpenEnv),
+            ('door-close-v1', SawyerDoorCloseEnv),
+            ('shelf-place-v1', SawyerShelfPlaceEnv),
+            ('sweep-into-v1', SawyerSweepIntoGoalEnv),
+            ('lever-pull-v1', SawyerLeverPullEnv,)))
+    )
+))
 medium_mode_train_args_kwargs = {
     key: dict(args=[], kwargs={
         'obs_type': 'plain',
         'random_init': True,
-        'task_id' : _static_task_ids[key],
+        'task_id' : list(ALL_ENVIRONMENTS.keys()).index(key),
     })
     for key, _ in MEDIUM_MODE_CLS_DICT['train'].items()
 }
 
 medium_mode_test_args_kwargs = {
-    key: dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : _static_task_ids[key]})
+    key: dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : list(ALL_ENVIRONMENTS.keys()).index(key)})
     for key, _ in MEDIUM_MODE_CLS_DICT['test'].items()
 }
 
@@ -208,66 +216,70 @@ MEDIUM_MODE_ARGS_KWARGS = dict(
 '''
     ML45 environments and arguments
 '''
-HARD_MODE_CLS_DICT = dict(
-    train={
-        'reach-v1': SawyerReachPushPickPlaceEnv,
-        'push-v1': SawyerReachPushPickPlaceEnv,
-        'pick-place-v1': SawyerReachPushPickPlaceEnv,
-        'reach-wall-v1': SawyerReachPushPickPlaceWallEnv,
-        'pick-place-wall-v1': SawyerReachPushPickPlaceWallEnv,
-        'push-wall-v1': SawyerReachPushPickPlaceWallEnv,
-        'door-open-v1': SawyerDoorEnv,
-        'door-close-v1': SawyerDoorCloseEnv,
-        'drawer-open-v1': SawyerDrawerOpenEnv,
-        'drawer-close-v1': SawyerDrawerCloseEnv,
-        'button-press-topdown-v1': SawyerButtonPressTopdownEnv,
-        'button-press-v1': SawyerButtonPressEnv,
-        'button-press-topdown-wall-v1': SawyerButtonPressTopdownWallEnv,
-        'button-press-wall-v1': SawyerButtonPressWallEnv,
-        'peg-insert-side-v1': SawyerPegInsertionSideEnv,
-        'peg-unplug-side-v1': SawyerPegUnplugSideEnv,
-        'window-open-v1': SawyerWindowOpenEnv,
-        'window-close-v1': SawyerWindowCloseEnv,
-        'dissassemble-v1': SawyerNutDisassembleEnv,
-        'hammer-v1': SawyerHammerEnv,
-        'plate-slide-v1': SawyerPlateSlideEnv,
-        'plate-slide-side-v1': SawyerPlateSlideSideEnv,
-        'plate-slide-back-v1': SawyerPlateSlideBackEnv,
-        'plate-slide-back-side-v1': SawyerPlateSlideBackSideEnv,
-        'handle-press-v1': SawyerHandlePressEnv,
-        'handle-pull-v1': SawyerHandlePullEnv,
-        'handle-press-side-v1': SawyerHandlePressSideEnv,
-        'handle-pull-side-v1': SawyerHandlePullSideEnv,
-        'stick-push-v1': SawyerStickPushEnv,
-        'stick-pull-v1': SawyerStickPullEnv,
-        'basket-ball-v1': SawyerBasketballEnv,
-        'soccer-v1': SawyerSoccerEnv,
-        'faucet-open-v1': SawyerFaucetOpenEnv,
-        'faucet-close-v1': SawyerFaucetCloseEnv,
-        'coffee-push-v1': SawyerCoffeePushEnv,
-        'coffee-pull-v1': SawyerCoffeePullEnv,
-        'coffee-button-v1': SawyerCoffeeButtonEnv,
-        'sweep-v1': SawyerSweepEnv,
-        'sweep-into-v1': SawyerSweepIntoGoalEnv,
-        'pick-out-of-hole-v1': SawyerPickOutOfHoleEnv,
-        'assembly-v1': SawyerNutAssemblyEnv,
-        'shelf-place-v1': SawyerShelfPlaceEnv,
-        'push-back-v1': SawyerPushBackEnv,
-        'lever-pull-v1': SawyerLeverPullEnv,
-        'dial-turn-v1': SawyerDialTurnEnv,
-    },
-    test={
-        'bin-picking-v1': SawyerBinPickingEnv,
-        'box-close-v1': SawyerBoxCloseEnv,
-        'hand-insert-v1': SawyerHandInsertEnv,
-        'door-lock-v1': SawyerDoorLockEnv,
-        'door-unlock-v1': SawyerDoorUnlockEnv,
-    },
-)
+HARD_MODE_CLS_DICT = OrderedDict((
+    ('train', 
+        OrderedDict((
+            ('reach-v1', SawyerReachPushPickPlaceEnv),
+            ('push-v1', SawyerReachPushPickPlaceEnv),
+            ('pick-place-v1', SawyerReachPushPickPlaceEnv),
+            ('reach-wall-v1', SawyerReachPushPickPlaceWallEnv),
+            ('pick-place-wall-v1', SawyerReachPushPickPlaceWallEnv),
+            ('push-wall-v1', SawyerReachPushPickPlaceWallEnv),
+            ('door-open-v1', SawyerDoorEnv),
+            ('door-close-v1', SawyerDoorCloseEnv),
+            ('drawer-open-v1', SawyerDrawerOpenEnv),
+            ('drawer-close-v1', SawyerDrawerCloseEnv),
+            ('button-press-topdown-v1', SawyerButtonPressTopdownEnv),
+            ('button-press-v1', SawyerButtonPressEnv),
+            ('button-press-topdown-wall-v1', SawyerButtonPressTopdownWallEnv),
+            ('button-press-wall-v1', SawyerButtonPressWallEnv),
+            ('peg-insert-side-v1', SawyerPegInsertionSideEnv),
+            ('peg-unplug-side-v1', SawyerPegUnplugSideEnv),
+            ('window-open-v1', SawyerWindowOpenEnv),
+            ('window-close-v1', SawyerWindowCloseEnv),
+            ('dissassemble-v1', SawyerNutDisassembleEnv),
+            ('hammer-v1', SawyerHammerEnv),
+            ('plate-slide-v1', SawyerPlateSlideEnv),
+            ('plate-slide-side-v1', SawyerPlateSlideSideEnv),
+            ('plate-slide-back-v1', SawyerPlateSlideBackEnv),
+            ('plate-slide-back-side-v1', SawyerPlateSlideBackSideEnv),
+            ('handle-press-v1', SawyerHandlePressEnv),
+            ('handle-pull-v1', SawyerHandlePullEnv),
+            ('handle-press-side-v1', SawyerHandlePressSideEnv),
+            ('handle-pull-side-v1', SawyerHandlePullSideEnv),
+            ('stick-push-v1', SawyerStickPushEnv),
+            ('stick-pull-v1', SawyerStickPullEnv),
+            ('basketball-v1', SawyerBasketballEnv),
+            ('soccer-v1', SawyerSoccerEnv),
+            ('faucet-open-v1', SawyerFaucetOpenEnv),
+            ('faucet-close-v1', SawyerFaucetCloseEnv),
+            ('coffee-push-v1', SawyerCoffeePushEnv),
+            ('coffee-pull-v1', SawyerCoffeePullEnv),
+            ('coffee-button-v1', SawyerCoffeeButtonEnv),
+            ('sweep-v1', SawyerSweepEnv),
+            ('sweep-into-v1', SawyerSweepIntoGoalEnv),
+            ('pick-out-of-hole-v1', SawyerPickOutOfHoleEnv),
+            ('assembly-v1', SawyerNutAssemblyEnv),
+            ('shelf-place-v1', SawyerShelfPlaceEnv),
+            ('push-back-v1', SawyerPushBackEnv),
+            ('lever-pull-v1', SawyerLeverPullEnv),
+            ('dial-turn-v1', SawyerDialTurnEnv),
+        ))
+    ),
+    ('test', 
+        OrderedDict((
+            ('bin-picking-v1', SawyerBinPickingEnv),
+            ('box-close-v1', SawyerBoxCloseEnv),
+            ('hand-insert-v1', SawyerHandInsertEnv),
+            ('door-lock-v1', SawyerDoorLockEnv),
+            ('door-unlock-v1', SawyerDoorUnlockEnv),
+        ))
+    )
+))
 
 
 def _hard_mode_args_kwargs(env_cls, key):
-    kwargs = dict(random_init=True, obs_type='plain', task_id=_static_task_ids[key])
+    kwargs = dict(random_init=True, obs_type='plain', task_id=list(ALL_ENVIRONMENTS.keys()).index(key))
     if key == 'reach-v1' or key == 'reach-wall-v1':
         kwargs['task_type'] = 'reach'
     elif key == 'push-v1' or key == 'push-wall-v1':

--- a/tests/metaworld/envs/test_multitask_env.py
+++ b/tests/metaworld/envs/test_multitask_env.py
@@ -223,3 +223,16 @@ def test_task_name():
 
     _, _, _, info = env.step(env.action_space.sample())
     assert info['task_name'] in task_names
+
+def test_observation_space():
+    pass
+
+def test_action_space():
+    pass
+
+def test_augment_observation():
+    pass
+
+def test_static_task_ids():
+    pass
+

--- a/tests/metaworld/envs/test_multitask_env.py
+++ b/tests/metaworld/envs/test_multitask_env.py
@@ -1,18 +1,17 @@
 import pytest
 import numpy as np
 
-from metaworld.benchmarks import ML10
-from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_CLS_DICT, MEDIUM_MODE_ARGS_KWARGS
+from metaworld.benchmarks import ML10, ML45
+from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_CLS_DICT, MEDIUM_MODE_ARGS_KWARGS, ALL_ENVIRONMENTS
 from metaworld.envs.mujoco.multitask_env import MultiClassMultiTaskEnv
 from metaworld.envs.mujoco.sawyer_xyz import SawyerReachPushPickPlaceEnv
 from metaworld.envs.mujoco.sawyer_xyz import SawyerReachPushPickPlaceWallEnv
 from metaworld.envs.mujoco.sawyer_xyz.env_lists import HARD_MODE_LIST
 
-
 @pytest.mark.parametrize('env_cls', HARD_MODE_LIST)
 def test_single_env_multi_goals_discrete(env_cls):
     env_cls_dict = {'wrapped': env_cls}
-    env_args_kwargs = {'wrapped': dict(args=[], kwargs={'obs_type': 'plain'})}
+    env_args_kwargs = {'wrapped': dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : 1})}
     multi_task_env = MultiClassMultiTaskEnv(
         task_env_cls_dict=env_cls_dict,
         task_args_kwargs=env_args_kwargs,
@@ -35,9 +34,8 @@ def test_single_env_multi_goals_discrete(env_cls):
     step_obs, _, _, _ = multi_task_env.step(multi_task_env.action_space.sample())
     assert np.all(multi_task_env.observation_space.shape == reset_obs.shape)
     assert np.all(multi_task_env.observation_space.shape == step_obs.shape)
-    assert reset_obs[multi_task_env._max_plain_dim:][tasks_with_goals[0]['goal']] == 1
-    assert step_obs[multi_task_env._max_plain_dim:][tasks_with_goals[0]['goal']] == 1
-    assert np.sum(reset_obs[multi_task_env._max_plain_dim:]) == 1
+    assert reset_obs[multi_task_env._max_obs_dim:][env_args_kwargs['wrapped']['kwargs']['task_id'] + tasks_with_goals[0]['goal']] == 1
+    assert step_obs[multi_task_env._max_obs_dim:][env_args_kwargs['wrapped']['kwargs']['task_id'] + tasks_with_goals[0]['goal']] == 1
     assert np.sum(reset_obs[multi_task_env._max_plain_dim:]) == 1
 
 
@@ -48,7 +46,7 @@ def test_multienv_multigoals_fully_discretized(env_list):
         for i, env_cls in enumerate(env_list)
     }
     env_args_kwargs = {
-        'env-{}'.format(i): dict(args=[], kwargs={'obs_type': 'plain'})
+        'env-{}'.format(i): dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : i})
         for i, _ in enumerate(env_list)
     }
     multi_task_env = MultiClassMultiTaskEnv(
@@ -80,15 +78,14 @@ def test_multienv_multigoals_fully_discretized(env_list):
 
     task_name = multi_task_env._task_names[tasks_with_goals[0]['task']]
     goal = tasks_with_goals[0]['goal']
-    plain_dim = multi_task_env._max_plain_dim
-    task_start_index = multi_task_env._env_discrete_index[task_name] + multi_task_env.active_env._state_goal.shape[0]
-
+    plain_dim = multi_task_env._max_obs_dim
+    goal_dim = 3
+    task_start_index = goal_dim + multi_task_env.active_task
     # TODO these dims are ugly... rewrite assertion later
-    assert reset_obs[plain_dim:][task_start_index + goal] == 1, reset_obs
-    assert step_obs[plain_dim:][task_start_index + goal] == 1, step_obs
+    assert reset_obs[plain_dim:][task_start_index] == 1, reset_obs
+    assert step_obs[plain_dim:][task_start_index] == 1, step_obs
     assert np.sum(reset_obs[plain_dim + task_start_index: plain_dim + task_start_index + multi_task_env._n_discrete_goals]) == 1
     assert np.sum(reset_obs[plain_dim + task_start_index: plain_dim + task_start_index + multi_task_env._n_discrete_goals]) == 1
-
 
 @pytest.mark.parametrize('env_list', [HARD_MODE_LIST[10:12], HARD_MODE_LIST[30:33]])
 def test_multienv_single_goal(env_list):
@@ -97,7 +94,7 @@ def test_multienv_single_goal(env_list):
         for i, env_cls in enumerate(env_list)
     }
     env_args_kwargs = {
-        'env-{}'.format(i): dict(args=[], kwargs={'obs_type': 'plain'})
+        'env-{}'.format(i): dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : i})
         for i, _ in enumerate(env_list)
     }
     multi_task_env = MultiClassMultiTaskEnv(
@@ -125,7 +122,7 @@ def test_multitask_env_images(env_list):
         for i, env_cls in enumerate(env_list)
     }
     env_args_kwargs = {
-        'env-{}'.format(i): dict(args=[], kwargs={'obs_type': 'plain'})
+        'env-{}'.format(i): dict(args=[], kwargs={'obs_type': 'plain', 'task_id' : i})
         for i, _ in enumerate(env_list)
     }
     multi_task_env = MultiClassMultiTaskEnv(
@@ -151,7 +148,7 @@ def test_reach_push_pick_place(env_cls):
     task_types = ['pick_place', 'reach', 'push']
     env_dict = {t: env_cls for t in task_types}
     env_args_kwargs = {
-        t: dict(args=[], kwargs={'task_type': t, 'obs_type': 'plain'})
+        t: dict(args=[], kwargs={'task_type': t, 'obs_type': 'plain', 'task_id' : 1})
         for t in task_types
     }
 
@@ -224,15 +221,42 @@ def test_task_name():
     _, _, _, info = env.step(env.action_space.sample())
     assert info['task_name'] in task_names
 
-def test_observation_space():
-    pass
+@pytest.mark.parametrize('observation_type', ['plain', 'with_goal_id', 'with_goal_and_id', 'with_goal'])
+def test_observation_space(observation_type):
+    env_cls_dict = {'pick-place-v1': MEDIUM_MODE_CLS_DICT['train']['pick-place-v1']}
+    env_args_kwargs = {key: MEDIUM_MODE_ARGS_KWARGS['train'][key]
+                       for key in env_cls_dict.keys()}
+    multi_task_env = MultiClassMultiTaskEnv(
+        task_env_cls_dict=env_cls_dict,
+        task_args_kwargs=env_args_kwargs,
+        sample_goals=True,
+        obs_type=observation_type,
+    )
+    if observation_type == 'plain':
+        assert multi_task_env.observation_space.shape == (9, )
+    elif observation_type == 'with_goal_id':
+        assert multi_task_env.observation_space.shape == (59, )
+    elif observation_type == 'with_goal_and_id':
+        assert multi_task_env.observation_space.shape == (62, )
+    elif observation_type == 'with_goal':
+        assert multi_task_env.observation_space.shape == (12, )
+
 
 def test_action_space():
-    pass
+    env_cls_dict = {'pick-place-v1': MEDIUM_MODE_CLS_DICT['train']['pick-place-v1']}
+    env_args_kwargs = {key: MEDIUM_MODE_ARGS_KWARGS['train'][key]
+                       for key in env_cls_dict.keys()}
+    multi_task_env = MultiClassMultiTaskEnv(
+        task_env_cls_dict=env_cls_dict,
+        task_args_kwargs=env_args_kwargs,
+        sample_goals=True,
+        obs_type="plain",
+    )
+    assert multi_task_env.action_space.shape == (4, )
 
-def test_augment_observation():
-    pass
 
-def test_static_task_ids():
-    pass
+@pytest.mark.parametrize('task_name', list(ALL_ENVIRONMENTS.keys())[:10])
+def test_static_task_ids(task_name):
+    env = ML45.from_task(task_name)
+    assert env.active_task == list(ALL_ENVIRONMENTS.keys()).index(task_name)
 


### PR DESCRIPTION
  * Ensure that static task ID is maintained.
    
    After a call to discretize envs was made, the static task_id would be
    ignored by the class, and task_envs would be assigned a new random task_id
    
    Also addresses #71

* Make naming of envs standard across benchmarks
    
    - removes some typos as well as ensures that envs have the same task name across benchmarks

* Addition of Static Task IDS
    
    Addresses #68
    
    - Adds static task ids for all metaworld envs to ensure
      the ordering of envs is maintained regardless of python version
    - Ensures that when envs are constructed using the from_task api
      that they will always have the same task_id regardless of
      how many other envs are constructed.
    - Addition of tests for static task IDS and missing tests in
      Multiclassmultitaskenv.py
