### PR TITLE
Add from_task API for multitask benchmarks

### DIFF
--- a/metaworld/benchmarks/mt10.py
+++ b/metaworld/benchmarks/mt10.py
@@ -6,12 +6,20 @@ from metaworld.envs.mujoco.env_dict import EASY_MODE_ARGS_KWARGS, EASY_MODE_CLS_
 
 class MT10(MultiClassMultiTaskEnv, Benchmark):
 
-    def __init__(self, env_type='train', sample_all=False):
-        assert env_type == 'train' or env_type == 'test'
+    def __init__(self, env_type="train", sample_all=False, task_name=None):
+        if task_name is not None:
+            if task_name not in EASY_MODE_CLS_DICT:
+                raise ValueError("{} does not exist in MT10 tasks".format(
+                    task_name))
+            cls_dict = {task_name: EASY_MODE_CLS_DICT[task_name]}
+            args_kwargs = {task_name: EASY_MODE_ARGS_KWARGS[task_name]}
+        else:
+            cls_dict = EASY_MODE_CLS_DICT
+            args_kwargs = EASY_MODE_ARGS_KWARGS
 
         super().__init__(
-            task_env_cls_dict=EASY_MODE_CLS_DICT,
-            task_args_kwargs=EASY_MODE_ARGS_KWARGS,
+            task_env_cls_dict=cls_dict,
+            task_args_kwargs=args_kwargs,
             sample_goals=False,
             obs_type='with_goal_id',
             sample_all=sample_all,)
@@ -23,3 +31,10 @@ class MT10(MultiClassMultiTaskEnv, Benchmark):
 
         self.discretize_goal_space(goals_dict)
         assert self._fully_discretized
+
+    @classmethod
+    def from_task(cls, task_name):
+        if task_name in EASY_MODE_CLS_DICT:
+            return cls(sample_all=True, task_name=task_name)
+        else:
+            raise ValueError('{} does not exist in MT10'.format(task_name))

--- a/metaworld/benchmarks/mt50.py
+++ b/metaworld/benchmarks/mt50.py
@@ -6,8 +6,7 @@ from metaworld.envs.mujoco.env_dict import HARD_MODE_ARGS_KWARGS, HARD_MODE_CLS_
 
 class MT50(MultiClassMultiTaskEnv, Benchmark):
 
-    def __init__(self, env_type='train', sample_all=False):
-        assert env_type == 'train' or env_type == 'test'
+    def __init__(self, env_type="train", sample_all=False, task_name=None):
 
         cls_dict = {}
         args_kwargs = {}
@@ -16,6 +15,12 @@ class MT50(MultiClassMultiTaskEnv, Benchmark):
                 cls_dict[task] = HARD_MODE_CLS_DICT[k][task]
                 args_kwargs[task] = HARD_MODE_ARGS_KWARGS[k][task]
         assert len(cls_dict.keys()) == 50
+        if task_name is not None:
+            if task_name not in cls_dict:
+                raise ValueError("{} does not exist in MT50 tasks".format(
+                    task_name))
+            cls_dict = {task_name: cls_dict[task_name]}
+            args_kwargs = {task_name: args_kwargs[task_name]}
 
         super().__init__(
             task_env_cls_dict=cls_dict,
@@ -31,3 +36,10 @@ class MT50(MultiClassMultiTaskEnv, Benchmark):
 
         self.discretize_goal_space(goals_dict)
         assert self._fully_discretized
+
+    @classmethod
+    def from_task(cls, task_name):
+        if task_name in HARD_MODE_CLS_DICT['train'] or HARD_MODE_CLS_DICT['test']:
+            return cls(sample_all=True, task_name=task_name)
+        else:
+            raise ValueError('{} does not exist in MT50'.format(task_name))


### PR DESCRIPTION
Added the from_task function to MT10 and MT50 so that users of those benchmarks can construct a single environment from the benchmark.