### PR TITLE
Replace MANIFEST.in with package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-graft metaworld/envs/assets 

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ extras['dev'] = [
     'pytest>=3.6',
 ]
 
-
 setup(
     name='metaworld',
     packages=find_packages(),
     include_package_data=True,
+    package_data={'metaworld': ['metaworld/envs/assets/*']},
     install_requires=required,
     extras_require=extras,
 )


### PR DESCRIPTION
This is necessary to allow modern tools like poetry and pipenv to
install metaworld.

I have confirmed that the assets end up in the build directory, but I'm not 100% positive I did everything right. Having said that, everything seems to work.