### PR TITLE
Implement the new API

### DIFF
--- a/metaworld/__init__.py
+++ b/metaworld/__init__.py
@@ -1,0 +1,185 @@
+"""Proposal for a simple, understandable MetaWorld API."""
+import abc
+import pickle
+from collections import OrderedDict
+from typing import List, NamedTuple, Type
+
+import metaworld.envs.mujoco.env_dict as _env_dict
+
+
+EnvID = str
+
+
+class Task(NamedTuple):
+    """All data necessary to describe a single MDP.
+
+    Should be passed into a MetaWorldEnv's set_task method.
+    """
+
+    env_id: EnvID
+    data: bytes  # Contains env parameters like random_init and *a* goal
+
+
+class MetaWorldEnv:
+    """Environment that requires a task before use.
+
+    Takes no arguments to its constructor, and raises an exception if used
+    before `set_task` is called.
+    """
+
+    def set_task(self, task: Task) -> None:
+        """Set the task.
+
+        Raises:
+            ValueError: If task.env_id is different from the current task.
+
+        """
+
+
+class Benchmark(abc.ABC):
+    """A Benchmark.
+
+    When used to evaluate an algorithm, only a single instance should be used.
+    """
+
+    @abc.abstractmethod
+    def __init__(self):
+        pass
+
+    @property
+    def train_classes(self) -> 'OrderedDict[EnvID, Type]':
+        """Get all of the environment classes used for training."""
+        return self._train_classes
+
+    @property
+    def test_classes(self) -> 'OrderedDict[EnvID, Type]':
+        """Get all of the environment classes used for testing."""
+        return self._test_classes
+
+    @property
+    def train_tasks(self) -> List[Task]:
+        """Get all of the training tasks for this benchmark."""
+        return self._train_tasks
+
+    @property
+    def test_tasks(self) -> List[Task]:
+        """Get all of the test tasks for this benchmark."""
+        return self._test_tasks
+
+
+_ML_OVERRIDE = dict(obs_type='plain', random_init=True)
+_MT_OVERRIDE = dict(obs_type='with_goal_id', random_init=False)
+
+_N_GOALS = 50
+
+
+def _encode_task(env_id, data):
+    return Task(env_id=env_id, data=pickle.dumps(data))
+
+
+def _make_tasks(classes, args_kwargs, kwargs_override):
+    tasks = []
+    for (env_id, args) in args_kwargs.items():
+        assert len(args['args']) == 0
+        env_cls = classes[env_id]
+        goals = [env_cls._sample_goal_do_not_use() for _ in range(_N_GOALS)]
+        for goal in goals:
+            kwargs = args['kwargs'].copy()
+            del kwargs['task_id']
+            kwargs.update(dict(goal=goal, env_cls=env_cls))
+            kwargs.update(kwargs_override)
+            tasks.append(_encode_task(env_id, kwargs))
+    return tasks
+
+
+def _ml1_env_names():
+    key_train = _env_dict.HARD_MODE_ARGS_KWARGS['train']
+    key_test = _env_dict.HARD_MODE_ARGS_KWARGS['test']
+    tasks = sum([list(key_train)], list(key_test))
+    assert len(tasks) == 50
+    return tasks
+
+
+class ML1(Benchmark):
+
+    ENV_NAMES = _ml1_env_names()
+
+    def __init__(self, env_name):
+        super().__init__()
+        try:
+            cls = _env_dict.HARD_MODE_CLS_DICT['train'][env_name]
+            args_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['train'][env_name]
+        except KeyError:
+            cls = _env_dict.HARD_MODE_CLS_DICT['test'][env_name]
+            args_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['test'][env_name]
+        self._train_classes = OrderedDict([(env_name, cls)])
+        self._test_classes = self._train_classes
+        self._train_ = OrderedDict([(env_name, cls)])
+        self._train_tasks = _make_tasks(self._train_classes,
+                                        {env_name: args_kwargs},
+                                        _ML_OVERRIDE)
+        self._test_tasks = self._train_tasks
+
+
+class ML10(Benchmark):
+
+    def __init__(self):
+        super().__init__()
+        self._train_classes = _env_dict.MEDIUM_MODE_CLS_DICT['train']
+        self._test_classes = _env_dict.MEDIUM_MODE_CLS_DICT['test']
+        train_kwargs = _env_dict.medium_mode_train_args_kwargs
+        self._train_tasks = _make_tasks(self._train_classes,
+                                        train_kwargs,
+                                        _ML_OVERRIDE)
+        test_kwargs = _env_dict.medium_mode_test_args_kwargs
+        self._test_tasks = _make_tasks(self._test_classes,
+                                       test_kwargs,
+                                       _ML_OVERRIDE)
+
+
+class ML45(Benchmark):
+
+    def __init__(self):
+        super().__init__()
+        self._train_classes = _env_dict.HARD_MODE_CLS_DICT['train']
+        self._test_classes = _env_dict.HARD_MODE_CLS_DICT['test']
+        train_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['train']
+        self._train_tasks = _make_tasks(self._train_classes,
+                                        train_kwargs,
+                                        _ML_OVERRIDE)
+        self._test_tasks = _make_tasks(self._test_classes,
+                                       _env_dict.HARD_MODE_ARGS_KWARGS['test'],
+                                       _ML_OVERRIDE)
+
+
+class MT10(Benchmark):
+
+    def __init__(self):
+        super().__init__()
+        self._train_classes = _env_dict.MEDIUM_MODE_CLS_DICT['train']
+        self._test_classes = []
+        train_kwargs = _env_dict.medium_mode_train_args_kwargs
+        self._train_tasks = _make_tasks(self._train_classes,
+                                        train_kwargs,
+                                        _MT_OVERRIDE)
+        self._test_tasks = OrderedDict()
+
+
+class MT50(Benchmark):
+
+    def __init__(self):
+        super().__init__()
+        self._train_classes = _env_dict.HARD_MODE_CLS_DICT['train'].copy()
+        # We're going to modify it, so make a copy
+        train_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['train'].copy()
+        test_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['test']
+        for (env_id, cls) in _env_dict.HARD_MODE_CLS_DICT['test'].items():
+            assert env_id not in self._train_classes
+            assert env_id not in train_kwargs
+            self._train_classes[env_id] = cls
+            train_kwargs[env_id] = test_kwargs[env_id]
+        self._test_classes = []
+        self._train_tasks = _make_tasks(self._train_classes,
+                                        train_kwargs,
+                                        _MT_OVERRIDE)
+        self._test_tasks = OrderedDict()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_assembly_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_assembly_peg.py
@@ -6,16 +6,17 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerNutAssemblyEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.75, 0.1)
+    goal_high = (0.1, 0.85, 0.1)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=True):
+    def __init__(self):
 
         liftThresh = 0.1
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (0, 0.6, 0.02)
         obj_high = (0, 0.6, 0.02)
-        goal_low = (-0.1, 0.75, 0.1)
-        goal_high = (0.1, 0.85, 0.1)
 
         super().__init__(
             self.model_name,
@@ -23,7 +24,7 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -43,13 +44,12 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
             np.array([1, 1, 1, 1]),
         )
 
-        goal_low = np.array(goal_low)
-        goal_high = np.array(goal_high)
+        self.goal_low = np.array(self.goal_low)
+        self.goal_high = np.array(self.goal_high)
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball.py
@@ -6,12 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerBasketballEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.85, 0.15)
+    goal_high = (0.1, 0.9+1e-7, 0.15)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
         liftThresh = 0.3
-        goal_low = (-0.1, 0.85, 0.15)
-        goal_high = (0.1, 0.9+1e-7, 0.15)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.6, 0.03)
@@ -23,7 +24,7 @@ class SawyerBasketballEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': .3,
@@ -43,10 +44,9 @@ class SawyerBasketballEnv(SawyerXYZEnv):
             np.array([1, 1, 1, 1]),
         )
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_bin_picking.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_bin_picking.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerBinPickingEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = np.array((-0.5, 0.40, 0.07))
+    hand_high = np.array((0.5, 1, 0.5))
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(goal_low, goal_high)
+
+    def __init__(self):
 
         liftThresh = 0.1
-        hand_low = (-0.5, 0.40, 0.07)
-        hand_high = (0.5, 1, 0.5)
         obj_low = (-0.5, 0.40, 0.07)
         obj_high = (0.5, 1, 0.5)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -31,9 +35,6 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
-
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.liftThresh = liftThresh
         self.max_path_length = 150
@@ -49,11 +50,9 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
         )
 
         self.goal_and_obj_space = Box(
-            np.hstack((goal_low[:2], obj_low[:2])),
-            np.hstack((goal_high[:2], obj_high[:2])),
+            np.hstack((self.goal_low[:2], obj_low[:2])),
+            np.hstack((self.goal_high[:2], obj_high[:2])),
         )
-
-        self.goal_space = Box(goal_low, goal_high)
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_box_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_box_close.py
@@ -6,11 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerBoxCloseEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    goal_low = (-0.1, 0.85, 0.133)
+    goal_high = (0.1, 0.95, 0.133)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+    def __init__(self):
 
         liftThresh = 0.12
-        goal_low = (-0.1, 0.85, 0.133)
-        goal_high = (0.1, 0.95, 0.133)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.05, 0.55, 0.02)
@@ -22,7 +24,7 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': .3,
@@ -42,11 +44,10 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
 
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerButtonPressEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.05)
         obj_high = (0.1, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0., 0.9, 0.04], dtype=np.float32),
@@ -28,8 +32,6 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
         self.goal = np.array([0, 0.78, 0.12])
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -42,7 +44,6 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=True):
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.05)
         obj_high = (0.1, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.8, 0.05], dtype=np.float32),
@@ -30,8 +34,6 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -44,7 +46,6 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown_wall.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=True):
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.05, 0.8, 0.05)
         obj_high = (0.05, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.8, 0.05], dtype=np.float32),
@@ -30,8 +34,6 @@ class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -44,7 +46,6 @@ class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_wall.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerButtonPressWallEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=True):
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.05, 0.85, 0.05)
         obj_high = (0.05, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0., 0.9, 0.05], dtype=np.float32),
@@ -30,8 +34,6 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -45,7 +47,6 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
             np.array(obj_high),
         )
 
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_button.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_button.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerCoffeeButtonEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.28)
         obj_high = (0.1, 0.9, 0.28)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.9, 0.28]),
@@ -31,8 +35,6 @@ class SawyerCoffeeButtonEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -45,7 +47,6 @@ class SawyerCoffeeButtonEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_pull.py
@@ -5,11 +5,12 @@ from metaworld.envs.env_util import get_asset_full_path
 from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 class SawyerCoffeePullEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.6, 0.05)
+    goal_high = (0.1, 0.7, 0.3)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
-        goal_low = (-0.1, 0.6, 0.05)
-        goal_high = (0.1, 0.7, 0.3)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.05, 0.75, 0.)
@@ -21,7 +22,7 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.75, 0.]),
@@ -39,11 +40,10 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
 
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_push.py
@@ -6,15 +6,16 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerCoffeePushEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.8, 0.05)
+    goal_high = (-0.1, 0.8, 0.05)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.6, 0.)
         obj_high = (0.1, 0.7, 0.)
-        goal_low = (-0.1, 0.8, 0.05)
-        goal_high = (-0.1, 0.8, 0.05)
 
         super().__init__(
             self.model_name,
@@ -22,7 +23,7 @@ class SawyerCoffeePushEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -42,10 +43,9 @@ class SawyerCoffeePushEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_dial_turn.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_dial_turn.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerDialTurnEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.7, 0.05)
         obj_high = (0.1, 0.8, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.7, 0.05]),
@@ -29,8 +33,6 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
         self.goal = np.array([0., 0.73, 0.08])
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
         self.action_space = Box(
@@ -42,7 +44,6 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_disassemble_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_disassemble_peg.py
@@ -6,15 +6,17 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerNutDisassembleEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    goal_low = (-0.1, 0.75, 0.17)
+    goal_high = (0.1, 0.85, 0.17)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+    def __init__(self):
 
         liftThresh = 0.05
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (0.1, 0.75, 0.02)
         obj_high = (0., 0.85, 0.02)
-        goal_low = (-0.1, 0.75, 0.17)
-        goal_high = (0.1, 0.85, 0.17)
 
         super().__init__(
             self.model_name,
@@ -22,7 +24,7 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -43,10 +45,9 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door.py
@@ -6,17 +6,21 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerDoorEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (0., 0.85, 0.1)
         obj_high = (0.1, 0.95, 0.1)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
         self.init_config = {
@@ -30,9 +34,7 @@ class SawyerDoorEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        self.random_init = random_init
-        goal_low = self.hand_low
-        goal_high = self.hand_high
+        self.random_init = False
 
         self.max_path_length = 150
 
@@ -45,7 +47,6 @@ class SawyerDoorEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_close.py
@@ -4,8 +4,8 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv
 
 
 class SawyerDoorCloseEnv(SawyerDoorEnv):
-    def __init__(self, random_init=False):
-        super().__init__(random_init=random_init)
+    def __init__(self):
+        super().__init__()
 
         self.init_config = {
             'obj_init_angle': 0.3,

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_lock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_lock.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerDoorLockEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, -0.15)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
 
-        hand_low = (-0.5, 0.40, -0.15)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.1)
         obj_high = (0.1, 0.85, 0.1)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.85, 0.1]),
@@ -30,8 +34,6 @@ class SawyerDoorLockEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -44,7 +46,6 @@ class SawyerDoorLockEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
             np.hstack((self.hand_high, obj_high,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_unlock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_unlock.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerDoorUnlockEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = (-0.5, 0.40, -0.15)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, -0.15)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.1)
         obj_high = (0.1, 0.85, 0.1)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.85, 0.1]),
@@ -28,8 +32,6 @@ class SawyerDoorUnlockEnv(SawyerXYZEnv):
         self.goal = np.array([0, 0.85, 0.1])
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -42,7 +44,6 @@ class SawyerDoorUnlockEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_close.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerDrawerCloseEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.9, 0.04)
         obj_high = (0.1, 0.9, 0.04)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': np.array([0.3, ], dtype=np.float32),
@@ -31,8 +35,6 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -45,7 +47,6 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_open.py
@@ -6,17 +6,21 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerDrawerOpenEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.9, 0.04)
         obj_high = (0.1, 0.9, 0.04)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
         self.init_config = {
@@ -31,10 +35,8 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
-        self.random_init = random_init
+        self.random_init = False
         self.max_path_length = 150
 
         self.action_space = Box(
@@ -46,7 +48,6 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_close.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerFaucetCloseEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = (-0.5, 0.40, -0.15)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, -0.15)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.05)
         obj_high = (0.1, 0.85, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.8, 0.05]),
@@ -29,8 +33,6 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
         self.hand_init_pos = self.init_config['hand_init_pos']
         self.obj_init_pos = self.init_config['obj_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -43,7 +45,6 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_open.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerFaucetOpenEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    hand_low = (-0.5, 0.40, -0.15)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, -0.15)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.05, 0.8, 0.05)
         obj_high = (0.05, 0.85, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.8, 0.05]),
@@ -28,8 +32,6 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
         self.goal = np.array([0.1, 0.8, 0.115])
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -42,7 +44,6 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_hammer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_hammer.py
@@ -6,15 +6,16 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerHammerEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    goal_low = (0., 0.85, 0.05)
+    goal_high = (0.3, 0.9, 0.05)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
+    def __init__(self):
 
         liftThresh = 0.09
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.5, 0.02)
         obj_high = (0.1, 0.6, 0.02)
-        goal_low = (0., 0.85, 0.05)
-        goal_high = (0.3, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
@@ -22,7 +23,7 @@ class SawyerHammerEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'hammer_init_pos': np.array([0, 0.6, 0.02]),
@@ -41,10 +42,9 @@ class SawyerHammerEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_hand_insert.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_hand_insert.py
@@ -6,14 +6,16 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerHandInsertEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    goal_low = (-0.04, 0.8, -0.08)
+    goal_high = (0.04, 0.88, -0.08)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+    def __init__(self):
 
         hand_low = (-0.5, 0.40, -0.15)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.6, 0.02)
         obj_high = (0.1, 0.7, 0.02)
-        goal_low = (-0.04, 0.8, -0.08)
-        goal_high = (0.04, 0.88, -0.08)
 
         super().__init__(
             self.model_name,
@@ -21,7 +23,7 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.6, 0.02]),
@@ -41,10 +43,9 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press.py
@@ -6,21 +6,25 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerHandlePressEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=True):
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.05)
         obj_high = (0.1, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.9, 0.05]),
@@ -30,8 +34,6 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -44,7 +46,6 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press_side.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerHandlePressSideEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.35, 0.65, 0.05)
         obj_high = (-0.25, 0.75, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([-0.3, 0.7, 0.05]),
@@ -28,9 +32,6 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
         self.goal = np.array([-0.2, 0.7, 0.14])
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
-
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -43,7 +44,6 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerHandlePullEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.1, 0.8, 0.05)
         obj_high = (0.1, 0.9, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.9, 0.05]),
@@ -29,8 +33,6 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -43,7 +45,6 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull_side.py
@@ -6,20 +6,24 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerHandlePullSideEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
+    def __init__(self):
+
         obj_low = (-0.35, 0.65, 0.05)
         obj_high = (-0.25, 0.75, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([-0.3, 0.7, 0.05]),
@@ -29,8 +33,6 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
 
@@ -43,7 +45,6 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull.py
@@ -6,18 +6,21 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerLeverPullEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, -0.15)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
-        hand_low = (-0.5, 0.40, -0.15)
-        hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.7, 0.05)
         obj_high = (0.1, 0.8, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
         self.init_config = {
@@ -28,10 +31,8 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
-        self.random_init = random_init
+        self.random_init = False
         self.max_path_length = 150
 
         self.action_space = Box(
@@ -43,7 +44,6 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side.py
@@ -6,22 +6,23 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPegInsertionSideEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
         liftThresh = 0.11
         hand_init_pos = (0, 0.6, 0.2)
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.5, 0.02)
         obj_high = (0.1, 0.7, 0.02)
-        goal_low = (-0.35, 0.5, 0.05)
-        goal_high = (-0.25, 0.8, 0.05)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
         self.init_config = {
@@ -32,10 +33,7 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
-
-        self.random_init = random_init
+        self.random_init = False
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
@@ -47,10 +45,9 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_unplug_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_unplug_side.py
@@ -6,12 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPegUnplugSideEnv(SawyerXYZEnv):
+    goal_low = (-0.25, 0.6, 0.05)
+    goal_high = (-0.15, 0.8, 0.05)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
         liftThresh = 0.04
-        goal_low = (-0.25, 0.6, 0.05)
-        goal_high = (-0.15, 0.8, 0.05)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.25, 0.6, 0.05)
@@ -23,7 +24,7 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([-0.225, 0.6, 0.05]),
@@ -45,7 +46,6 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_out_of_hole.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_out_of_hole.py
@@ -6,12 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.6, 0.15)
+    goal_high = (0.1, 0.7, 0.3)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=True):
+    def __init__(self):
 
         liftThresh = 0.11
-        goal_low = (-0.1, 0.6, 0.15)
-        goal_high = (0.1, 0.7, 0.3)
         hand_low = (-0.5, 0.40, -0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (0, 0.84, -0.03)
@@ -23,7 +24,7 @@ class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.84, -0.03]),
@@ -44,10 +45,9 @@ class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide.py
@@ -6,11 +6,12 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPlateSlideEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.85, 0.02)
+    goal_high = (0.1, 0.9, 0.02)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
-        goal_low = (-0.1, 0.85, 0.02)
-        goal_high = (0.1, 0.9, 0.02)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (0., 0.6, 0.015)
@@ -22,7 +23,7 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -42,10 +43,9 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back.py
@@ -6,11 +6,12 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPlateSlideBackEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.6, 0.015)
+    goal_high = (0.1, 0.6, 0.015)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
-        goal_low = (-0.1, 0.6, 0.015)
-        goal_high = (0.1, 0.6, 0.015)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (0., 0.85, 0.02)
@@ -22,7 +23,7 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -42,10 +43,9 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side.py
@@ -6,11 +6,12 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.6, 0.015)
+    goal_high = (0.1, 0.6, 0.015)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
-        goal_low = (-0.1, 0.6, 0.015)
-        goal_high = (0.1, 0.6, 0.015)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.25, 0.6, 0.02)
@@ -22,7 +23,7 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -42,10 +43,9 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_side.py
@@ -6,11 +6,12 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPlateSlideSideEnv(SawyerXYZEnv):
+    goal_low = (-0.3, 0.6, 0.02)
+    goal_high = (-0.25, 0.7, 0.02)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
-        goal_low = (-0.3, 0.6, 0.02)
-        goal_high = (-0.25, 0.7, 0.02)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (0., 0.6, 0.015)
@@ -22,7 +23,7 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_angle': 0.3,
@@ -42,10 +43,9 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_back.py
@@ -6,10 +6,12 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerPushBackEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    goal_low = (-0.1, 0.6, 0.02)
+    goal_high = (0.1, 0.7, 0.02)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        goal_low = (-0.1, 0.6, 0.02)
-        goal_high = (0.1, 0.7, 0.02)
+    def __init__(self):
+
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.8, 0.02)
@@ -21,7 +23,7 @@ class SawyerPushBackEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos':np.array([0, 0.8, 0.02]),
@@ -41,10 +43,9 @@ class SawyerPushBackEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place.py
@@ -6,11 +6,12 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.8, 0.05)
+    goal_high = (0.1, 0.9, 0.3)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False, task_type='pick_place'):
+    def __init__(self):
         liftThresh = 0.04
-        goal_low=(-0.1, 0.8, 0.05)
-        goal_high=(0.1, 0.9, 0.3)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.6, 0.02)
@@ -24,30 +25,17 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.task_type = task_type
+        self.task_type = None
         self.init_config = {
             'obj_init_angle': .3,
             'obj_init_pos': np.array([0, 0.6, 0.02]),
             'hand_init_pos': np.array([0, .6, .2]),
         }
 
-        # we only do one task from [pick_place, reach, push]
-        # per instance of SawyerReachPushPickPlaceEnv.
-        # Please only set task_type from constructor.
-        if self.task_type == 'pick_place':
-            self.goal = np.array([0.1, 0.8, 0.2])
-        elif self.task_type == 'reach':
-            self.goal = np.array([-0.1, 0.8, 0.2])
-        elif self.task_type == 'push':
-            self.goal = np.array([0.1, 0.8, 0.02])
-        else:
-            raise NotImplementedError
-
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        self.random_init = random_init
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
@@ -57,10 +45,9 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
@@ -68,6 +55,18 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
         )
 
         self.num_resets = 0
+
+    def _set_task_inner(self, *, task_type, **kwargs):
+        super()._set_task_inner(**kwargs)
+        self.task_type = task_type
+        if self.task_type == 'pick_place':
+            self.goal = np.array([0.1, 0.8, 0.2])
+        elif self.task_type == 'reach':
+            self.goal = np.array([-0.1, 0.8, 0.2])
+        elif self.task_type == 'push':
+            self.goal = np.array([0.1, 0.8, 0.02])
+        else:
+            raise NotImplementedError
         self.reset()
 
     @property

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place_wall.py
@@ -6,12 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
+    goal_low = (-0.05, 0.85, 0.05)
+    goal_high = (0.05, 0.9, 0.3)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False, task_type='pick_place'):
+    def __init__(self):
 
         liftThresh = 0.04
-        goal_low = (-0.05, 0.85, 0.05)
-        goal_high = (0.05, 0.9, 0.3)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.05, 0.6, 0.015)
@@ -25,26 +26,14 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
-        self.task_type = task_type
+        self.task_type = None
         self.init_config = {
             'obj_init_angle': .3,
             'obj_init_pos': np.array([0, 0.6, 0.02]),
             'hand_init_pos': np.array([0, .6, .2]),
         }
-        # we only do one task from [pick_place, reach, push]
-        # per instance of SawyerReachPushPickPlaceEnv.
-        # Please only set task_type from constructor.
-        if self.task_type == 'pick_place':
-            self.goal = np.array([0.05, 0.8, 0.2])
-        elif self.task_type == 'reach':
-            self.goal = np.array([-0.05, 0.8, 0.2])
-        elif self.task_type == 'push':
-            self.goal = np.array([0.05, 0.8, 0.015])
-        else:
-            raise NotImplementedError
-
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.obj_init_pos = self.init_config['obj_init_pos']
         self.hand_init_pos = self.init_config['hand_init_pos']
@@ -58,10 +47,9 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),
@@ -69,6 +57,18 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
         )
 
         self.num_resets = 0
+
+    def _set_task_inner(self, *, task_type, **kwargs):
+        super()._set_task_inner(**kwargs)
+        self.task_type = task_type
+        if self.task_type == 'pick_place':
+            self.goal = np.array([0.05, 0.8, 0.2])
+        elif self.task_type == 'reach':
+            self.goal = np.array([-0.05, 0.8, 0.2])
+        elif self.task_type == 'push':
+            self.goal = np.array([0.05, 0.8, 0.015])
+        else:
+            raise NotImplementedError
         self.reset()
 
     @property

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place.py
@@ -6,12 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerShelfPlaceEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.8, 0.001)
+    goal_high = (0.1, 0.9, 0.001)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
         liftThresh = 0.04
-        goal_low = (-0.1, 0.8, 0.001)
-        goal_high = (0.1, 0.9, 0.001)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.5, 0.02)
@@ -33,7 +34,7 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        self.random_init = random_init
+        self.random_init = False
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
@@ -43,10 +44,9 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_soccer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_soccer.py
@@ -6,10 +6,11 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerSoccerEnv(SawyerXYZEnv):
-    def __init__(self, random_init=False):
+    goal_low = (-0.1, 0.8, 0.03)
+    goal_high = (0.1, 0.9, 0.03)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
+    def __init__(self):
 
-        goal_low = (-0.1, 0.8, 0.03)
-        goal_high = (0.1, 0.9, 0.03)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.6, 0.03)
@@ -21,7 +22,7 @@ class SawyerSoccerEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos': np.array([0, 0.6, 0.03]),
@@ -41,10 +42,9 @@ class SawyerSoccerEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_pull.py
@@ -6,12 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerStickPullEnv(SawyerXYZEnv):
+    goal_low = np.array((0.3, 0.4, 0.02))
+    goal_high = np.array((0.4, 0.5, 0.02))
+    goal_space = Box(goal_low, goal_high)
 
-    def __init__(self, random_init=True):
+    def __init__(self):
 
         liftThresh = 0.04
-        goal_low = (0.3, 0.4, 0.02)
-        goal_high = (0.4, 0.5, 0.02)
         hand_low = (-0.5, 0.35, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.55, 0.02)
@@ -23,7 +24,7 @@ class SawyerStickPullEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'stick_init_pos': np.array([0, 0.6, 0.02]),
@@ -45,10 +46,9 @@ class SawyerStickPullEnv(SawyerXYZEnv):
         self.obj_init_pos = np.array([0.2, 0.69, 0.04])
         self.obj_init_qpos = np.array([0., 0.09])
         self.obj_space = Box(np.array(obj_low), np.array(obj_high))
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
 
         self.observation_space = Box(

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_push.py
@@ -6,11 +6,13 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerStickPushEnv(SawyerXYZEnv):
-    def __init__(self, random_init=True):
+    goal_low = (0.4, 0.55, 0.02)
+    goal_high = (0.4, 0.6, 0.02)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+    def __init__(self):
 
         liftThresh = 0.04
-        goal_low = (0.4, 0.55, 0.02)
-        goal_high = (0.4, 0.6, 0.02)
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.08, 0.58, 0.02)
@@ -22,7 +24,7 @@ class SawyerStickPushEnv(SawyerXYZEnv):
             hand_high=hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'stick_init_pos': np.array([-0.1, 0.6, 0.02]),
@@ -44,10 +46,9 @@ class SawyerStickPushEnv(SawyerXYZEnv):
         self.obj_init_pos = np.array([0.2, 0.6, 0.04])
         self.obj_init_qpos = np.array([0.0, 0.0])
         self.obj_space = Box(np.array(obj_low), np.array(obj_high))
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
 
         self.observation_space = Box(

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep.py
@@ -6,22 +6,26 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerSweepEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1.0, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+
+    def __init__(self):
 
         init_puck_z = 0.1
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1.0, 0.5)
         obj_low = (-0.1, 0.6, 0.02)
         obj_high = (0.1, 0.7, 0.02)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
-        self.random_init = random_init
+        self.random_init = False
 
         self.init_config = {
             'obj_init_pos':np.array([0., 0.6, 0.02]),
@@ -33,8 +37,6 @@ class SawyerSweepEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
         self.max_path_length = 150
         self.init_puck_z = init_puck_z
@@ -48,7 +50,6 @@ class SawyerSweepEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_into_goal.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_into_goal.py
@@ -6,10 +6,11 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
+    goal_low = (-0.1, 0.85, 0.05)
+    goal_high = (0.1, 0.9, 0.3)
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
-        goal_low = (-0.1, 0.85, 0.05)
-        goal_high = (0.1, 0.9, 0.3)
+    def __init__(self):
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.6, 0.02)
@@ -31,7 +32,7 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        self.random_init = random_init
+        self.random_init = False
         self.max_path_length = 150
 
         self.action_space = Box(
@@ -40,10 +41,9 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
         )
 
         self.obj_and_goal_space = Box(
-            np.hstack((obj_low, goal_low)),
-            np.hstack((obj_high, goal_high)),
+            np.hstack((obj_low, self.goal_low)),
+            np.hstack((obj_high, self.goal_high)),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close.py
@@ -6,19 +6,22 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerWindowCloseEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+    def __init__(self):
 
         liftThresh = 0.02
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
         obj_low = (0., 0.75, 0.15)
         obj_high = (0., 0.9, 0.15)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
         self.init_config = {
@@ -31,10 +34,8 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
-        self.random_init = random_init
+        self.random_init = False
         self.max_path_length = 150
         self.liftThresh = liftThresh
 
@@ -47,7 +48,6 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open.py
@@ -6,19 +6,23 @@ from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
 
 
 class SawyerWindowOpenEnv(SawyerXYZEnv):
+    hand_low = (-0.5, 0.40, 0.05)
+    hand_high = (0.5, 1, 0.5)
+    goal_low = hand_low
+    goal_high = hand_high
+    goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-    def __init__(self, random_init=False):
+
+    def __init__(self):
 
         liftThresh = 0.02
-        hand_low = (-0.5, 0.40, 0.05)
-        hand_high = (0.5, 1, 0.5)
         obj_low = (-0.1, 0.7, 0.16)
         obj_high = (0.1, 0.9, 0.16)
 
         super().__init__(
             self.model_name,
-            hand_low=hand_low,
-            hand_high=hand_high,
+            hand_low=self.hand_low,
+            hand_high=self.hand_high,
         )
 
         self.init_config = {
@@ -31,10 +35,8 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        goal_low = self.hand_low
-        goal_high = self.hand_high
 
-        self.random_init = random_init
+        self.random_init = False
         self.max_path_length = 150
         self.liftThresh = liftThresh
 
@@ -47,7 +49,6 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
             np.array(obj_low),
             np.array(obj_high),
         )
-        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
             np.hstack((self.hand_low, obj_low,)),

--- a/tests/integration/test_new_api.py
+++ b/tests/integration/test_new_api.py
@@ -1,0 +1,109 @@
+import pytest
+
+from metaworld import ML1, ML10, ML45, MT10, MT50
+from tests.helpers import step_env
+
+
+STEPS = 3
+
+
+@pytest.mark.parametrize('env_name', ML1.ENV_NAMES)
+def test_all_ml1(env_name):
+    ml1 = ML1(env_name)
+    train_env_instances = {env_id: env_cls()
+                           for (env_id, env_cls) in ml1.train_classes.items()}
+    for task in ml1.train_tasks:
+        env = train_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in train_env_instances.values():
+        env.close()
+    del train_env_instances
+
+    test_env_instances = {env_id: env_cls()
+                          for (env_id, env_cls) in ml1.test_classes.items()}
+    for task in ml1.test_tasks:
+        env = test_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in test_env_instances.values():
+        env.close()
+    del test_env_instances
+
+
+def test_all_ml10():
+    ml10 = ML10()
+    train_env_instances = {env_id: env_cls()
+                           for (env_id, env_cls) in ml10.train_classes.items()}
+    for task in ml10.train_tasks:
+        env = train_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in train_env_instances.values():
+        env.close()
+    del train_env_instances
+
+    test_env_instances = {env_id: env_cls()
+                          for (env_id, env_cls) in ml10.test_classes.items()}
+    for task in ml10.test_tasks:
+        env = test_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in test_env_instances.values():
+        env.close()
+    del test_env_instances
+
+
+def test_all_ml45():
+    ml45 = ML45()
+    train_env_instances = {env_id: env_cls()
+                           for (env_id, env_cls) in ml45.train_classes.items()}
+    for task in ml45.train_tasks:
+        env = train_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in train_env_instances.values():
+        env.close()
+    del train_env_instances
+
+    test_env_instances = {env_id: env_cls()
+                          for (env_id, env_cls) in ml45.test_classes.items()}
+    for task in ml45.test_tasks:
+        env = test_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in test_env_instances.values():
+        env.close()
+    del test_env_instances
+
+
+def test_all_mt10():
+    mt10 = MT10()
+    train_env_instances = {env_id: env_cls()
+                           for (env_id, env_cls) in mt10.train_classes.items()}
+    for task in mt10.train_tasks:
+        env = train_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in train_env_instances.values():
+        env.close()
+    del train_env_instances
+
+    assert len(mt10.test_classes) == 0
+    assert len(mt10.test_tasks) == 0
+
+
+def test_all_mt50():
+    mt50 = MT50()
+    train_env_instances = {env_id: env_cls()
+                           for (env_id, env_cls) in mt50.train_classes.items()}
+    for task in mt50.train_tasks:
+        env = train_env_instances[task.env_id]
+        env.set_task(task)
+        step_env(env, max_path_length=STEPS)
+    for env in train_env_instances.values():
+        env.close()
+    del train_env_instances
+
+    assert len(mt50.test_classes) == 0
+    assert len(mt50.test_tasks) == 0


### PR DESCRIPTION
This API aims to simplify usage and fix bugs (such as random_init being
set wrong) by removing as many arguments as possible from the API.

In the process, it makes using metaworld potentially much more
efficient.

However, this changes breaks the old API.

It also does not fix the goal being re-sampled on reset when
random_init=True.