### PR TITLE
Added Observation Space Getter and Test Helper

### DIFF
--- a/metaworld/envs/mujoco/multitask_env.py
+++ b/metaworld/envs/mujoco/multitask_env.py
@@ -108,11 +108,7 @@ class MultiClassMultiTaskEnv(gym.Env):
             obs_dim = self._max_obs_dim + _NUM_METAWORLD_ENVS
         else:
             raise Exception("invalid obs_type, obs_type was {}".format(self._obs_type))
-        observation_space = Box(
-            self._augment_observation(self.active_env.observation_space.low),
-            self._augment_observation(self.active_env.observation_space.high),
-        )
-        return observation_space
+        return Box(low=-np.inf, high=np.inf, shape=(obs_dim,))
 
     def set_task(self, task):
         if self._sample_goals:

--- a/metaworld/envs/mujoco/multitask_env.py
+++ b/metaworld/envs/mujoco/multitask_env.py
@@ -101,14 +101,18 @@ class MultiClassMultiTaskEnv(gym.Env):
 
     @property
     def observation_space(self):
-        """ TODO not complete, needs support for different observation types"""
+        """TODO not complete, needs support for different observation types."""
         if self._obs_type == "plain":
             obs_dim = self._max_obs_dim
         elif self._obs_type == "with_goal_id":
             obs_dim = self._max_obs_dim + _NUM_METAWORLD_ENVS
         else:
             raise Exception("invalid obs_type, obs_type was {}".format(self._obs_type))
-        return Box(low=-np.inf, high=np.inf, shape=(obs_dim,))
+        observation_space = Box(
+            self._augment_observation(self.active_env.observation_space.low),
+            self._augment_observation(self.active_env.observation_space.high),
+        )
+        return observation_space
 
     def set_task(self, task):
         if self._sample_goals:
@@ -150,11 +154,9 @@ class MultiClassMultiTaskEnv(gym.Env):
                 shape=(self._max_obs_dim - np.prod(obs.shape),)
             )
             obs = np.concatenate([obs, zeros])
-
         # augment the observation based on obs_type:
         if self._obs_type == 'with_goal_id':
             obs = np.concatenate([obs, self.active_task_one_hot])
-
         return obs
 
     def reset(self, **kwargs):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,19 +3,21 @@ import glfw
 
 
 def step_env(env, max_path_length=100, iterations=1,
-             render=True, check_obs_space=False):
+             render=True, check_obs_space=True):
     """Step env helper."""
     for _ in range(iterations):
         env.reset()
         for _ in range(max_path_length):
-            obs, reward, done, info = env.step(env.action_space.sample())
+            obs, _, done, info = env.step(env.action_space.sample())
             assert 'goal' in info
             if hasattr(env, 'active_env'):
                 assert np.all(info['goal'].shape == env.active_env.goal_space.shape)
             else:
                 assert np.all(info['goal'].shape == env.goal_space.shape)
             if check_obs_space:
-                assert env.observation_space.contains(obs)
+                assert env.active_env.observation_space.contains(
+                    obs[:env.active_env.observation_space.low.size]
+                )
             if render:
                 env.render()
             if done:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,17 +1,21 @@
 import numpy as np
 import glfw
 
-def step_env(env, max_path_length=100, iterations=1, render=True):
+
+def step_env(env, max_path_length=100, iterations=1,
+             render=True, check_obs_space=False):
     """Step env helper."""
     for _ in range(iterations):
         env.reset()
         for _ in range(max_path_length):
-            _, _, done, info = env.step(env.action_space.sample())
+            obs, reward, done, info = env.step(env.action_space.sample())
             assert 'goal' in info
             if hasattr(env, 'active_env'):
                 assert np.all(info['goal'].shape == env.active_env.goal_space.shape)
             else:
                 assert np.all(info['goal'].shape == env.goal_space.shape)
+            if check_obs_space:
+                assert env.observation_space.contains(obs)
             if render:
                 env.render()
             if done:


### PR DESCRIPTION
### Basic Observation Space Bounds Checker
As requested by @ryanjulian. This commit adds the following features:
* ~~Users can now get observation space for the active env in a MultiClassMultiTaskEnv Object. Temporarily supports 'with_goal_id' observations by following same observation augmentation feature as all standard observations in the MultiClassMultiTaskEnv Class.~~ *Removed*.
* `step_env()` tests helper now supports optional check if observation space bounds are being maintained.