### PR TITLE
Made reach,push,pick-place env solvable

### DIFF
--- a/metaworld/envs/assets/sawyer_xyz/sawyer_pick_place_v2.xml
+++ b/metaworld/envs/assets/sawyer_xyz/sawyer_pick_place_v2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mujoco>
+    <include file="shared_config.xml"></include>
+
+    <worldbody>
+        <include file="sawyer_xyz_base.xml"></include>
+        <body name="obj" pos="0 0.6 0.02">
+
+            <joint name="objjoint" type="free" limited='false' damping="0." armature="0."/>
+
+            <inertial pos="0 0 0" mass=".75" diaginertia="8.80012e-04 8.80012e-04 8.80012e-04"/>
+            <geom name="objGeom" type="cylinder" pos="0 0 0" solimp="0.99 0.99 0.01"
+                  size="0.03 0.015" rgba="1 0 0 1" solref="0.01 1"
+                  contype="1" conaffinity="1" friction="1 0.1 0.002" condim="4" material="wood"
+            />
+        </body>
+
+        <site name="goal" pos="0.1 0.8 0.2" size="0.02"
+              rgba="0 0 0.8 1"/>
+
+
+    </worldbody>
+
+    <actuator>
+        <position ctrllimited="true" ctrlrange="-1 1" joint="r_close" kp="400"  user="1"/>
+        <position ctrllimited="true" ctrlrange="-1 1" joint="l_close" kp="400"  user="1"/>
+
+    </actuator>
+
+</mujoco>

--- a/metaworld/envs/assets/sawyer_xyz/sawyer_push_v2.xml
+++ b/metaworld/envs/assets/sawyer_xyz/sawyer_push_v2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mujoco>
+    <include file="shared_config.xml"></include>
+
+    <worldbody>
+        <include file="sawyer_xyz_base.xml"></include>
+        <body name="obj" pos="0 0.6 0.02">
+
+            <joint name="objjoint" type="free" limited='false' damping="0." armature="0."/>
+
+            <inertial pos="0 0 0" mass=".75" diaginertia="8.80012e-04 8.80012e-04 8.80012e-04"/>
+            <geom name="objGeom" type="cylinder" pos="0 0 0" solimp="0.99 0.99 0.01"
+                  size="0.03 0.015" rgba="1 0 0 1" solref="0.01 1"
+                  contype="1" conaffinity="1" friction="1 0.1 0.002" condim="4" material="wood"
+            />
+        </body>
+
+        <site name="goal" pos="0.1 0.8 0.02" size="0.02"
+              rgba="0 0.8 0 1"/>
+
+
+    </worldbody>
+
+    <actuator>
+        <position ctrllimited="true" ctrlrange="-1 1" joint="r_close" kp="400"  user="1"/>
+        <position ctrllimited="true" ctrlrange="-1 1" joint="l_close" kp="400"  user="1"/>
+
+    </actuator>
+
+</mujoco>

--- a/metaworld/envs/assets/sawyer_xyz/sawyer_reach_v2.xml
+++ b/metaworld/envs/assets/sawyer_xyz/sawyer_reach_v2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mujoco>
+    <include file="shared_config.xml"></include>
+
+    <worldbody>
+        <include file="sawyer_xyz_base.xml"></include>
+        <body name="obj" pos="0 0.6 0.02">
+
+            <joint name="objjoint" type="free" limited='false' damping="0." armature="0."/>
+
+            <inertial pos="0 0 0" mass=".75" diaginertia="8.80012e-04 8.80012e-04 8.80012e-04"/>
+            <geom name="objGeom" type="cylinder" pos="0 0 0" solimp="0.99 0.99 0.01"
+                  size="0.03 0.015" rgba="1 0 0 1" solref="0.01 1"
+                  contype="1" conaffinity="1" friction="1 0.1 0.002" condim="4" material="wood"
+            />
+        </body>
+
+        <site name="goal" pos="-0.1 0.8 0.2" size="0.02"
+              rgba="0.8 0 0 1"/>
+
+
+    </worldbody>
+
+    <actuator>
+        <position ctrllimited="true" ctrlrange="-1 1" joint="r_close" kp="400"  user="1"/>
+        <position ctrllimited="true" ctrlrange="-1 1" joint="l_close" kp="400"  user="1"/>
+
+    </actuator>
+
+</mujoco>

--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -1,6 +1,9 @@
 from collections import OrderedDict
 
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place import SawyerReachPushPickPlaceEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_v2 import SawyerReachEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_v2 import SawyerPushEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_place_v2 import SawyerPickPlaceEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_v2 import SawyerDoorEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_hand_insert import SawyerHandInsertEnv
@@ -103,7 +106,10 @@ ALL_ENVIRONMENTS = OrderedDict((
 
 ALL_V2_ENVIRONMENTS = OrderedDict((
     ('door-open-v2', SawyerDoorEnvV2),
-    ('door-close-v2', SawyerDoorCloseEnvV2),))
+    ('door-close-v2', SawyerDoorCloseEnvV2),
+    ('reach-v2', SawyerReachEnvV2),
+    ('push-v2', SawyerPushEnvV2),
+    ('pick-place-v2', SawyerPickPlaceEnvV2),))
 
 _NUM_METAWORLD_ENVS = len(ALL_ENVIRONMENTS)
 

--- a/metaworld/envs/mujoco/sawyer_xyz/__init__.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/__init__.py
@@ -14,6 +14,9 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_hammer import SawyerHammerEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_hand_insert import SawyerHandInsertEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_lever_pull import SawyerLeverPullEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_insertion_side import SawyerPegInsertionSideEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_place_v2 import SawyerPickPlaceEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_v2 import SawyerPushEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_v2 import SawyerReachEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place import SawyerReachPushPickPlaceEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_shelf_place import SawyerShelfPlaceEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_pull import SawyerStickPullEnv

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_v2.py
@@ -1,0 +1,254 @@
+import numpy as np
+from gym.spaces import Box
+
+from metaworld.envs.env_util import get_asset_full_path
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+
+
+class SawyerPickPlaceEnvV2(SawyerXYZEnv):
+    """
+    Motivation for V2:
+        V1 was completely unsolvable because the observation didn't say where
+        to move after picking up the puck.
+    Changelog from V1 to V2:
+        - (6/15/20) Added a 3 element vector to the observation. This vector
+            points from the end effector to the goal coordinate.
+            i.e. (self._state_goal - pos_hand)
+        - (6/15/20) Separated reach-push-pick-place into 3 separate envs.
+    """
+    def __init__(self, random_init=False):
+        liftThresh = 0.04
+
+        goal_low = (-0.1, 0.8, 0.05)
+        goal_high = (0.1, 0.9, 0.3)
+        hand_low = (-0.5, 0.40, 0.05)
+        hand_high = (0.5, 1, 0.5)
+        obj_low = (-0.1, 0.6, 0.02)
+        obj_high = (0.1, 0.7, 0.02)
+
+        super().__init__(
+            self.model_name,
+            hand_low=hand_low,
+            hand_high=hand_high,
+        )
+
+        self.init_config = {
+            'obj_init_angle': .3,
+            'obj_init_pos': np.array([0, 0.6, 0.02]),
+            'hand_init_pos': np.array([0, .6, .2]),
+        }
+
+        self.goal = np.array([0.1, 0.8, 0.2])
+
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.obj_init_pos = self.init_config['obj_init_pos']
+        self.hand_init_pos = self.init_config['hand_init_pos']
+
+        self.random_init = random_init
+        self.liftThresh = liftThresh
+        self.max_path_length = 150
+
+        self.action_space = Box(
+            np.array([-1, -1, -1, -1]),
+            np.array([1, 1, 1, 1]),
+        )
+
+        self.obj_and_goal_space = Box(
+            np.hstack((obj_low, goal_low)),
+            np.hstack((obj_high, goal_high)),
+        )
+        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+        self.observation_space = Box(
+            np.hstack((self.hand_low, obj_low, np.array(goal_low) - self.hand_high)),
+            np.hstack((self.hand_high, obj_high, self.hand_high - np.array(goal_low))),
+        )
+
+        self.num_resets = 0
+        self.reset()
+
+    @property
+    def model_name(self):
+        return get_asset_full_path('sawyer_xyz/sawyer_pick_and_place_v2.xml')
+
+    def step(self, action):
+        self.set_xyz_action(action[:3])
+        self.do_simulation([action[-1], -action[-1]])
+        # The marker seems to get reset every time you do a simulation
+        self._set_goal_marker(self._state_goal)
+
+        ob = self._get_obs()
+        obs_dict = self._get_obs_dict()
+
+        rew, reach_dist, pick_rew, placing_dist = self.compute_reward(action, obs_dict)
+        success = float(placing_dist <= 0.07)
+
+        info = {
+            'reachDist': reach_dist,
+            'pickRew': pick_rew,
+            'epRew': rew,
+            'goalDist': placing_dist,
+            'success': success,
+            'goal': self.goal
+        }
+
+        self.curr_path_length += 1
+        return ob, rew, False, info
+
+    def _get_obs(self):
+        pos_hand = self.get_endeff_pos()
+        pos_obj = self.data.get_geom_xpos('objGeom')
+        hand_to_goal = self._state_goal - pos_hand
+
+        flat_obs = np.concatenate((pos_hand, pos_obj, hand_to_goal))
+        return np.concatenate([flat_obs, ])
+
+    def _get_obs_dict(self):
+        return dict(
+            state_observation=self._get_obs(),
+            state_desired_goal=self._state_goal,
+            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
+        )
+
+    def _set_goal_marker(self, goal):
+        self.data.site_xpos[self.model.site_name2id('goal')] = goal[:3]
+
+    def _set_obj_xyz(self, pos):
+        qpos = self.data.qpos.flat.copy()
+        qvel = self.data.qvel.flat.copy()
+        qpos[9:12] = pos.copy()
+        qvel[9:15] = 0
+        self.set_state(qpos, qvel)
+
+    def fix_extreme_obj_pos(self, orig_init_pos):
+        # This is to account for meshes for the geom and object are not
+        # aligned. If this is not done, the object could be initialized in an
+        # extreme position
+        diff = self.get_body_com('obj')[:2] - \
+               self.data.get_geom_xpos('objGeom')[:2]
+        adjusted_pos = orig_init_pos[:2] + diff
+        # The convention we follow is that body_com[2] is always 0,
+        # and geom_pos[2] is the object height
+        return [
+            adjusted_pos[0],
+            adjusted_pos[1],
+            self.data.get_geom_xpos('objGeom')[-1]
+        ]
+
+    def reset_model(self):
+        self._reset_hand()
+        self._state_goal = self.goal.copy()
+        self.obj_init_pos = self.fix_extreme_obj_pos(self.init_config['obj_init_pos'])
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.objHeight = self.data.get_geom_xpos('objGeom')[2]
+        self.heightTarget = self.objHeight + self.liftThresh
+
+        if self.random_init:
+            goal_pos = np.random.uniform(
+                self.obj_and_goal_space.low,
+                self.obj_and_goal_space.high,
+                size=(self.obj_and_goal_space.low.size),
+            )
+            self._state_goal = goal_pos[3:]
+            while np.linalg.norm(goal_pos[:2] - self._state_goal[:2]) < 0.15:
+                goal_pos = np.random.uniform(
+                    self.obj_and_goal_space.low,
+                    self.obj_and_goal_space.high,
+                    size=(self.obj_and_goal_space.low.size),
+                )
+                self._state_goal = goal_pos[3:]
+            self._state_goal = goal_pos[-3:]
+            self.obj_init_pos = goal_pos[:3]
+
+        self._set_goal_marker(self._state_goal)
+        self._set_obj_xyz(self.obj_init_pos)
+        self.maxPlacingDist = np.linalg.norm(
+            np.array([self.obj_init_pos[0],
+                      self.obj_init_pos[1],
+                      self.heightTarget]) -
+            np.array(self._state_goal)) + self.heightTarget
+        self.target_reward = 1000*self.maxPlacingDist + 1000*2
+        self.num_resets += 1
+
+        return self._get_obs()
+
+    def _reset_hand(self):
+        for _ in range(10):
+            self.data.set_mocap_pos('mocap', self.hand_init_pos)
+            self.data.set_mocap_quat('mocap', np.array([1, 0, 1, 0]))
+            self.do_simulation([-1, 1], self.frame_skip)
+
+        finger_right, finger_left = (
+            self.get_site_pos('rightEndEffector'),
+            self.get_site_pos('leftEndEffector')
+        )
+        self.init_finger_center = (finger_right + finger_left) / 2
+        self.pick_completed = False
+
+    def compute_reward(self, actions, obs):
+        obs = obs['state_observation']
+        pos_obj = obs[3:6]
+
+        finger_right, finger_left = (
+            self.get_site_pos('rightEndEffector'),
+            self.get_site_pos('leftEndEffector')
+        )
+        finger_center = (finger_right + finger_left) / 2
+        heightTarget = self.heightTarget
+
+        goal = self._state_goal
+        assert np.all(goal == self.get_site_pos('goal'))
+
+        tolerance = 0.01
+        self.pick_completed = pos_obj[2] >= (heightTarget - tolerance)
+
+        reach_dist = np.linalg.norm(finger_center - pos_obj)
+        placing_dist = np.linalg.norm(pos_obj - goal)
+
+        def obj_dropped():
+            # Object on the ground, far away from the goal, and from the gripper
+            # Can tweak the margin limits
+            return (pos_obj[2] < (self.objHeight + 0.005))\
+                   and (placing_dist > 0.02)\
+                   and (reach_dist > 0.02)
+
+        def reach_reward():
+            reach_xy = np.linalg.norm(pos_obj[:-1] - finger_center[:-1])
+            z_rew = np.linalg.norm(finger_center[-1] - self.init_finger_center[-1])
+
+            reach_rew = -reach_dist if reach_xy < 0.05 else -reach_xy - 2*z_rew
+            # Incentive to close fingers when reachDist is small
+            if reach_dist < 0.05:
+                reach_rew = -reach_dist + max(actions[-1], 0)/50
+
+            return reach_rew, reach_dist
+
+        def pick_reward():
+            h_scale = 100
+            if self.pick_completed and not obj_dropped():
+                return h_scale * heightTarget
+            elif (reach_dist < 0.1) and (pos_obj[2] > (self.objHeight + 0.005)):
+                return h_scale * min(heightTarget, pos_obj[2])
+            else:
+                return 0
+
+        def place_reward():
+            c1 = 1000
+            c2 = 0.01
+            c3 = 0.001
+            if self.pick_completed and reach_dist < 0.1 and not obj_dropped():
+                place_rew = c1 * (self.maxPlacingDist - placing_dist) + \
+                            c1 * (np.exp(-(placing_dist ** 2) / c2) +
+                                  np.exp(-(placing_dist ** 2) / c3))
+                place_rew = max(place_rew, 0)
+                return [place_rew, placing_dist]
+            else:
+                return [0, placing_dist]
+
+        reach_rew, reach_dist = reach_reward()
+        pick_rew = pick_reward()
+        place_rew, placing_dist = place_reward()
+        assert ((place_rew >= 0) and (pick_rew >= 0))
+
+        reward = reach_rew + pick_rew + place_rew
+        return [reward, reach_dist, pick_rew, placing_dist]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_v2.py
@@ -1,0 +1,214 @@
+import numpy as np
+from gym.spaces import Box
+
+from metaworld.envs.env_util import get_asset_full_path
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+
+
+class SawyerPushEnvV2(SawyerXYZEnv):
+    """
+    Motivation for V2:
+        V1 was completely unsolvable because the observation didn't say where
+        to move after reaching the puck.
+    Changelog from V1 to V2:
+        - (6/15/20) Added a 3 element vector to the observation. This vector
+            points from the end effector to the goal coordinate.
+            i.e. (self._state_goal - pos_hand)
+        - (6/15/20) Separated reach-push-pick-place into 3 separate envs.
+    """
+    def __init__(self, random_init=False):
+        lift_thresh = 0.04
+
+        goal_low = (-0.1, 0.8, 0.05)
+        goal_high = (0.1, 0.9, 0.3)
+        hand_low = (-0.5, 0.40, 0.05)
+        hand_high = (0.5, 1, 0.5)
+        obj_low = (-0.1, 0.6, 0.02)
+        obj_high = (0.1, 0.7, 0.02)
+
+        super().__init__(
+            self.model_name,
+            hand_low=hand_low,
+            hand_high=hand_high,
+        )
+
+        self.init_config = {
+            'obj_init_angle': .3,
+            'obj_init_pos': np.array([0., 0.6, 0.02]),
+            'hand_init_pos': np.array([0., 0.6, 0.2]),
+        }
+
+        self.goal = np.array([0.1, 0.8, 0.02])
+
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.obj_init_pos = self.init_config['obj_init_pos']
+        self.hand_init_pos = self.init_config['hand_init_pos']
+
+        self.random_init = random_init
+        self.liftThresh = lift_thresh
+        self.max_path_length = 150
+
+        self.action_space = Box(
+            np.array([-1, -1, -1, -1]),
+            np.array([+1, +1, +1, +1]),
+        )
+
+        self.obj_and_goal_space = Box(
+            np.hstack((obj_low, goal_low)),
+            np.hstack((obj_high, goal_high)),
+        )
+        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+        hand_to_goal_max = self.hand_high - np.array(goal_low)
+        self.observation_space = Box(
+            np.hstack((self.hand_low, obj_low, -hand_to_goal_max)),
+            np.hstack((self.hand_high, obj_high, hand_to_goal_max)),
+        )
+
+        self.num_resets = 0
+        self.reset()
+
+    @property
+    def model_name(self):
+        return get_asset_full_path('sawyer_xyz/sawyer_push_v2.xml')
+
+    def step(self, action):
+        self.set_xyz_action(action[:3])
+        self.do_simulation([action[-1], -action[-1]])
+        # The marker seems to get reset every time you do a simulation
+        self._set_goal_marker(self._state_goal)
+
+        ob = self._get_obs()
+        obs_dict = self._get_obs_dict()
+
+        rew, reach_dist, push_dist = self.compute_reward(action, obs_dict)
+        success = float(push_dist <= 0.07)
+
+        info = {
+            'reachDist': reach_dist,
+            'epRew': rew,
+            'goalDist': push_dist,
+            'success': success,
+            'goal': self.goal
+        }
+
+        self.curr_path_length += 1
+        return ob, rew, False, info
+
+    def _get_obs(self):
+        pos_hand = self.get_endeff_pos()
+        pos_obj = self.data.get_geom_xpos('objGeom')
+        hand_to_goal = self._state_goal - pos_hand
+
+        flat_obs = np.concatenate((pos_hand, pos_obj, hand_to_goal))
+        return np.concatenate([flat_obs, ])
+
+    def _get_obs_dict(self):
+        return dict(
+            state_observation=self._get_obs(),
+            state_desired_goal=self._state_goal,
+            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
+        )
+
+    def _set_goal_marker(self, goal):
+        self.data.site_xpos[self.model.site_name2id('goal')] = goal[:3]
+
+    def _set_obj_xyz(self, pos):
+        qpos = self.data.qpos.flat.copy()
+        qvel = self.data.qvel.flat.copy()
+        qpos[9:12] = pos.copy()
+        qvel[9:15] = 0
+        self.set_state(qpos, qvel)
+
+    def fix_extreme_obj_pos(self, orig_init_pos):
+        # This is to account for meshes for the geom and object are not
+        # aligned. If this is not done, the object could be initialized in an
+        # extreme position
+        diff = self.get_body_com('obj')[:2] - \
+               self.data.get_geom_xpos('objGeom')[:2]
+        adjusted_pos = orig_init_pos[:2] + diff
+        # The convention we follow is that body_com[2] is always 0,
+        # and geom_pos[2] is the object height
+        return [
+            adjusted_pos[0],
+            adjusted_pos[1],
+            self.data.get_geom_xpos('objGeom')[-1]
+        ]
+
+    def reset_model(self):
+        self._reset_hand()
+        self._state_goal = self.goal.copy()
+        self.obj_init_pos = self.fix_extreme_obj_pos(self.init_config['obj_init_pos'])
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.objHeight = self.data.get_geom_xpos('objGeom')[2]
+        self.heightTarget = self.objHeight + self.liftThresh
+
+        if self.random_init:
+            goal_pos = np.random.uniform(
+                self.obj_and_goal_space.low,
+                self.obj_and_goal_space.high,
+                size=(self.obj_and_goal_space.low.size),
+            )
+            self._state_goal = goal_pos[3:]
+            while np.linalg.norm(goal_pos[:2] - self._state_goal[:2]) < 0.15:
+                goal_pos = np.random.uniform(
+                    self.obj_and_goal_space.low,
+                    self.obj_and_goal_space.high,
+                    size=(self.obj_and_goal_space.low.size),
+                )
+                self._state_goal = goal_pos[3:]
+            self._state_goal = np.concatenate((goal_pos[-3:-1], [self.obj_init_pos[-1]]))
+            self.obj_init_pos = np.concatenate((goal_pos[:2], [self.obj_init_pos[-1]]))
+
+        self._set_goal_marker(self._state_goal)
+        self._set_obj_xyz(self.obj_init_pos)
+        self.maxPushDist = np.linalg.norm(
+            self.obj_init_pos[:2] - np.array(self._state_goal)[:2])
+        self.target_reward = 1000*self.maxPushDist + 1000*2
+        self.num_resets += 1
+
+        return self._get_obs()
+
+    def _reset_hand(self):
+        for _ in range(10):
+            self.data.set_mocap_pos('mocap', self.hand_init_pos)
+            self.data.set_mocap_quat('mocap', np.array([1, 0, 1, 0]))
+            self.do_simulation([-1, 1], self.frame_skip)
+
+        finger_right, finger_left = (
+            self.get_site_pos('rightEndEffector'),
+            self.get_site_pos('leftEndEffector')
+        )
+        self.init_finger_center = (finger_right + finger_left) / 2
+        self.pickCompleted = False
+
+    def compute_reward(self, actions, obs):
+        obs = obs['state_observation']
+        pos_obj = obs[3:6]
+
+        finger_right, finger_left = (
+            self.get_site_pos('rightEndEffector'),
+            self.get_site_pos('leftEndEffector')
+        )
+        finger_center = (finger_right + finger_left) / 2
+
+        goal = self._state_goal
+        assert np.all(goal == self.get_site_pos('goal'))
+
+        c1 = 1000
+        c2 = 0.01
+        c3 = 0.001
+        reach_dist = np.linalg.norm(finger_center - pos_obj)
+        reach_rew = -reach_dist
+        
+        push_dist = np.linalg.norm(pos_obj[:2] - goal[:2])
+        if reach_dist < 0.05:
+            push_rew = c1 * (self.maxPushDist - push_dist) + \
+                       c1 * (np.exp(-(push_dist ** 2) / c2) +
+                             np.exp(-(push_dist ** 2) / c3))
+            push_rew = max(push_rew, 0)
+        else:
+            push_rew = 0
+
+        reward = reach_rew + push_rew
+        return [reward, reach_dist, push_dist]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_v2.py
@@ -1,0 +1,203 @@
+import numpy as np
+from gym.spaces import Box
+
+from metaworld.envs.env_util import get_asset_full_path
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+
+
+class SawyerReachEnvV2(SawyerXYZEnv):
+    """
+    Motivation for V2:
+        V1 was completely unsolvable because the observation didn't say where
+        to move (where to reach).
+    Changelog from V1 to V2:
+        - (6/15/20) Added a 3 element vector to the observation. This vector
+            points from the end effector to the goal coordinate.
+            i.e. (self._state_goal - pos_hand)
+        - (6/15/20) Separated reach-push-pick-place into 3 separate envs.
+    """
+    def __init__(self, random_init=False):
+        lift_thresh = 0.04
+
+        goal_low = (-0.1, 0.8, 0.05)
+        goal_high = (0.1, 0.9, 0.3)
+        hand_low = (-0.5, 0.40, 0.05)
+        hand_high = (0.5, 1, 0.5)
+        obj_low = (-0.1, 0.6, 0.02)
+        obj_high = (0.1, 0.7, 0.02)
+
+        super().__init__(
+            self.model_name,
+            hand_low=hand_low,
+            hand_high=hand_high,
+        )
+
+        self.init_config = {
+            'obj_init_angle': .3,
+            'obj_init_pos': np.array([0., 0.6, 0.02]),
+            'hand_init_pos': np.array([0., 0.6, 0.2]),
+        }
+
+        self.goal = np.array([-0.1, 0.8, 0.2])
+
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.obj_init_pos = self.init_config['obj_init_pos']
+        self.hand_init_pos = self.init_config['hand_init_pos']
+
+        self.random_init = random_init
+        self.liftThresh = lift_thresh
+        self.max_path_length = 150
+
+        self.action_space = Box(
+            np.array([-1, -1, -1, -1]),
+            np.array([+1, +1, +1, +1]),
+        )
+
+        self.obj_and_goal_space = Box(
+            np.hstack((obj_low, goal_low)),
+            np.hstack((obj_high, goal_high)),
+        )
+        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+        hand_to_goal_max = self.hand_high - np.array(goal_low)
+        self.observation_space = Box(
+            np.hstack((self.hand_low, obj_low, -hand_to_goal_max)),
+            np.hstack((self.hand_high, obj_high, hand_to_goal_max)),
+        )
+
+        self.num_resets = 0
+        self.reset()
+
+    @property
+    def model_name(self):
+        return get_asset_full_path('sawyer_xyz/sawyer_reach_v2.xml')
+
+    def step(self, action):
+        self.set_xyz_action(action[:3])
+        self.do_simulation([action[-1], -action[-1]])
+        # The marker seems to get reset every time you do a simulation
+        self._set_goal_marker(self._state_goal)
+
+        ob = self._get_obs()
+        obs_dict = self._get_obs_dict()
+
+        reward, reach_dist = self.compute_reward(action, obs_dict)
+        success = float(reach_dist <= 0.05)
+
+        info = {
+            'reachDist': reach_dist,
+            'epRew': reward,
+            'success': success,
+            'goal': self.goal
+        }
+
+        self.curr_path_length += 1
+        return ob, reward, False, info
+
+    def _get_obs(self):
+        pos_hand = self.get_endeff_pos()
+        pos_obj = self.data.get_geom_xpos('objGeom')
+        hand_to_goal = self._state_goal - pos_hand
+
+        flat_obs = np.concatenate((pos_hand, pos_obj, hand_to_goal))
+        return np.concatenate([flat_obs, ])
+
+    def _get_obs_dict(self):
+        return dict(
+            state_observation=self._get_obs(),
+            state_desired_goal=self._state_goal,
+            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
+        )
+
+    def _set_goal_marker(self, goal):
+        self.data.site_xpos[self.model.site_name2id('goal')] = goal[:3]
+
+    def _set_obj_xyz(self, pos):
+        qpos = self.data.qpos.flat.copy()
+        qvel = self.data.qvel.flat.copy()
+        qpos[9:12] = pos.copy()
+        qvel[9:15] = 0
+        self.set_state(qpos, qvel)
+
+    def fix_extreme_obj_pos(self, orig_init_pos):
+        # This is to account for meshes for the geom and object are not
+        # aligned. If this is not done, the object could be initialized in an
+        # extreme position
+        diff = self.get_body_com('obj')[:2] - \
+               self.data.get_geom_xpos('objGeom')[:2]
+        adjusted_pos = orig_init_pos[:2] + diff
+        # The convention we follow is that body_com[2] is always 0,
+        # and geom_pos[2] is the object height
+        return [
+            adjusted_pos[0],
+            adjusted_pos[1],
+            self.data.get_geom_xpos('objGeom')[-1]
+        ]
+
+    def reset_model(self):
+        self._reset_hand()
+        self._state_goal = self.goal.copy()
+        self.obj_init_pos = self.fix_extreme_obj_pos(self.init_config['obj_init_pos'])
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.objHeight = self.data.get_geom_xpos('objGeom')[2]
+        self.heightTarget = self.objHeight + self.liftThresh
+
+        if self.random_init:
+            goal_pos = np.random.uniform(
+                self.obj_and_goal_space.low,
+                self.obj_and_goal_space.high,
+                size=self.obj_and_goal_space.low.size,
+            )
+            self._state_goal = goal_pos[3:]
+            while np.linalg.norm(goal_pos[:2] - self._state_goal[:2]) < 0.15:
+                goal_pos = np.random.uniform(
+                    self.obj_and_goal_space.low,
+                    self.obj_and_goal_space.high,
+                    size=self.obj_and_goal_space.low.size,
+                )
+                self._state_goal = goal_pos[3:]
+            self._state_goal = goal_pos[-3:]
+            self.obj_init_pos = goal_pos[:3]
+
+        self._set_goal_marker(self._state_goal)
+        self._set_obj_xyz(self.obj_init_pos)
+        self.maxReachDist = np.linalg.norm(
+            self.init_finger_center - np.array(self._state_goal))
+        self.target_reward = 1000 * self.maxReachDist + 1000 * 2
+        self.num_resets += 1
+
+        return self._get_obs()
+
+    def _reset_hand(self):
+        for _ in range(10):
+            self.data.set_mocap_pos('mocap', self.hand_init_pos)
+            self.data.set_mocap_quat('mocap', np.array([1, 0, 1, 0]))
+            self.do_simulation([-1, 1], self.frame_skip)
+
+        finger_right, finger_left = (
+            self.get_site_pos('rightEndEffector'),
+            self.get_site_pos('leftEndEffector')
+        )
+        self.init_finger_center = (finger_right + finger_left) / 2
+        self.pickCompleted = False
+
+    def compute_reward(self, actions, obs):
+        finger_right, finger_left = (
+            self.get_site_pos('rightEndEffector'),
+            self.get_site_pos('leftEndEffector')
+        )
+        finger_center = (finger_right + finger_left) / 2
+
+        goal = self._state_goal
+        assert np.all(goal == self.get_site_pos('goal'))
+
+        c1 = 1000
+        c2 = 0.01
+        c3 = 0.001
+        reach_dist = np.linalg.norm(finger_center - goal)
+        reach_rew = c1 * (self.maxReachDist - reach_dist) + \
+                    c1 * (np.exp(-(reach_dist ** 2) / c2) +
+                          np.exp(-(reach_dist ** 2) / c3))
+
+        reach_rew = max(reach_rew, 0)
+        return [reach_rew, reach_dist]


### PR DESCRIPTION
Originally, if env was randomized, it was basically unsolvable (The best strategy would be to randomly flail about, and hope to touch the `_state_goal` coordinate by luck).
_Options to fix were:_
- Add info about `_state_goal` to observation
- Keep `_state_goal` constant and instead have `random_init` impact the sawyer's starting position

I chose the first option. Specifically, the observation now includes a 3D vector that points from the end effector to `_state_goal`. @ryanjulian suggested just a euclidean distance, but as far as I can tell, that wouldn't provide enough information to solve the env in a stateless manner; the policy would have to guess and check for directionality. Hopefully my method doesn't count as goal conditioning.