### PR TITLE
Scripted policies & V2 envs for window open/close

### DIFF
--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -10,8 +10,10 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_hand_insert import SawyerHandInsert
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_assembly_peg import SawyerNutAssemblyEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_sweep import SawyerSweepEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open import SawyerWindowOpenEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open_v2 import SawyerWindowOpenEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_hammer import SawyerHammerEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close import SawyerWindowCloseEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close_v2 import SawyerWindowCloseEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_dial_turn import SawyerDialTurnEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_lever_pull import SawyerLeverPullEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_open import SawyerDrawerOpenEnv
@@ -52,7 +54,7 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back import SawyerPlate
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_side import SawyerPlateSlideSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side import SawyerPlateSlideBackSideEnv
 
-ALL_ENVIRONMENTS = OrderedDict((
+ALL_V1_ENVIRONMENTS = OrderedDict((
     ('reach-v1', SawyerReachPushPickPlaceEnv),
     ('push-v1', SawyerReachPushPickPlaceEnv),
     ('pick-place-v1', SawyerReachPushPickPlaceEnv),
@@ -109,9 +111,11 @@ ALL_V2_ENVIRONMENTS = OrderedDict((
     ('door-close-v2', SawyerDoorCloseEnvV2),
     ('reach-v2', SawyerReachEnvV2),
     ('push-v2', SawyerPushEnvV2),
-    ('pick-place-v2', SawyerPickPlaceEnvV2),))
+    ('pick-place-v2', SawyerPickPlaceEnvV2),
+    ('window-open-v2', SawyerWindowOpenEnvV2),
+    ('window-close-v2', SawyerWindowCloseEnvV2),))
 
-_NUM_METAWORLD_ENVS = len(ALL_ENVIRONMENTS)
+_NUM_METAWORLD_ENVS = len(ALL_V1_ENVIRONMENTS)
 
 EASY_MODE_CLS_DICT = OrderedDict((
     ('reach-v1', SawyerReachPushPickPlaceEnv),
@@ -149,7 +153,7 @@ EASY_MODE_CLS_DICT = OrderedDict((
 EASY_MODE_ARGS_KWARGS = {
     key: dict(args=[],
               kwargs={
-                  'task_id': list(ALL_ENVIRONMENTS.keys()).index(key)
+                  'task_id': list(ALL_V1_ENVIRONMENTS.keys()).index(key)
               })
     for key, _ in EASY_MODE_CLS_DICT.items()
 }
@@ -199,13 +203,13 @@ MEDIUM_MODE_CLS_DICT = OrderedDict((
 medium_mode_train_args_kwargs = {
     key: dict(args=[], kwargs={
         'random_init': True,
-        'task_id' : list(ALL_ENVIRONMENTS.keys()).index(key),
+        'task_id' : list(ALL_V1_ENVIRONMENTS.keys()).index(key),
     })
     for key, _ in MEDIUM_MODE_CLS_DICT['train'].items()
 }
 
 medium_mode_test_args_kwargs = {
-    key: dict(args=[], kwargs={'task_id' : list(ALL_ENVIRONMENTS.keys()).index(key)})
+    key: dict(args=[], kwargs={'task_id' : list(ALL_V1_ENVIRONMENTS.keys()).index(key)})
     for key, _ in MEDIUM_MODE_CLS_DICT['test'].items()
 }
 
@@ -286,7 +290,7 @@ HARD_MODE_CLS_DICT = OrderedDict((
 def _hard_mode_args_kwargs(env_cls_, key_):
     del env_cls_
 
-    kwargs = dict(random_init=True, task_id=list(ALL_ENVIRONMENTS.keys()).index(key_))
+    kwargs = dict(random_init=True, task_id=list(ALL_V1_ENVIRONMENTS.keys()).index(key_))
     if key_ == 'reach-v1' or key_ == 'reach-wall-v1':
         kwargs['task_type'] = 'reach'
     elif key_ == 'push-v1' or key_ == 'push-wall-v1':

--- a/metaworld/envs/mujoco/sawyer_xyz/__init__.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/__init__.py
@@ -24,7 +24,9 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_push import SawyerStickPushEn
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_sweep import SawyerSweepEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_sweep_into_goal import SawyerSweepIntoGoalEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close import SawyerWindowCloseEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close_v2 import SawyerWindowCloseEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open import SawyerWindowOpenEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open_v2 import SawyerWindowOpenEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_button import SawyerCoffeeButtonEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_push import SawyerCoffeePushEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_pull import SawyerCoffeePullEnv

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
@@ -10,7 +10,7 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
     Motivation for V2:
         V1 was rarely solvable due to limited path length. The window usually
         only got ~25% closed before hitting max_path_length
-    Changelog:
+    Changelog from V1 to V2:
         - (6/15/20) Increased max_path_length from 150 to 200
     """
     def __init__(self, random_init=False):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
@@ -1,0 +1,174 @@
+import numpy as np
+from gym.spaces import  Box
+
+from metaworld.envs.env_util import get_asset_full_path
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+
+
+class SawyerWindowCloseEnvV2(SawyerXYZEnv):
+    """
+    Motivation for V2:
+        V1 was rarely solvable due to limited path length. The window usually
+        only got ~25% closed before hitting max_path_length
+    Changelog:
+        - (6/15/20) Increased max_path_length from 150 to 200
+    """
+    def __init__(self, random_init=False):
+
+        liftThresh = 0.02
+        hand_low = (-0.5, 0.40, 0.05)
+        hand_high = (0.5, 1, 0.5)
+        obj_low = (0., 0.75, 0.15)
+        obj_high = (0., 0.9, 0.15)
+
+        super().__init__(
+            self.model_name,
+            hand_low=hand_low,
+            hand_high=hand_high,
+        )
+
+        self.init_config = {
+            'obj_init_angle': 0.3,
+            'obj_init_pos': np.array([0.1, 0.785, 0.15], dtype=np.float32),
+            'hand_init_pos': np.array([0, 0.6, 0.2], dtype=np.float32),
+        }
+        self.goal = np.array([-0.08, 0.785, 0.15])
+        self.obj_init_pos = self.init_config['obj_init_pos']
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.hand_init_pos = self.init_config['hand_init_pos']
+
+        goal_low = self.hand_low
+        goal_high = self.hand_high
+
+        self.random_init = random_init
+        self.max_path_length = 200
+        self.liftThresh = liftThresh
+
+        self.action_space = Box(
+            np.array([-1, -1, -1, -1]),
+            np.array([1, 1, 1, 1]),
+        )
+
+        self.obj_and_goal_space = Box(
+            np.array(obj_low),
+            np.array(obj_high),
+        )
+        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+        self.observation_space = Box(
+            np.hstack((self.hand_low, obj_low,)),
+            np.hstack((self.hand_high, obj_high,)),
+        )
+
+        self.reset()
+
+    @property
+    def model_name(self):
+        return get_asset_full_path('sawyer_xyz/sawyer_window_horizontal.xml')
+
+    def step(self, action):
+        self.set_xyz_action(action[:3])
+        self.do_simulation([action[-1], -action[-1]])
+        # The marker seems to get reset every time you do a simulation
+        self._set_goal_marker(self._state_goal)
+        ob = self._get_obs()
+        obs_dict = self._get_obs_dict()
+        reward, reachDist, pickrew, pullDist = self.compute_reward(action, obs_dict)
+        self.curr_path_length += 1
+
+        info = {'reachDist': reachDist, 'goalDist': pullDist, 'epRew' : reward, 'pickRew':pickrew, 'success': float(pullDist <= 0.05)}
+        info['goal'] = self.goal
+
+        return ob, reward, False, info
+
+    def _get_obs(self):
+        hand = self.get_endeff_pos()
+        objPos =  self.get_site_pos('handleCloseStart')
+        flat_obs = np.concatenate((hand, objPos))
+
+        return np.concatenate([flat_obs,])
+
+    def _get_obs_dict(self):
+        hand = self.get_endeff_pos()
+        objPos =  self.get_site_pos('handleCloseStart')
+        flat_obs = np.concatenate((hand, objPos))
+
+        return dict(
+            state_observation=flat_obs,
+            state_desired_goal=self._state_goal,
+            state_achieved_goal=objPos,
+        )
+
+    def _set_goal_marker(self, goal):
+        self.data.site_xpos[self.model.site_name2id('goal')] = (
+            goal[:3]
+        )
+
+    def reset_model(self):
+        self._reset_hand()
+        self._state_goal = self.goal.copy()
+        self.objHeight = self.data.get_geom_xpos('handle')[2]
+        self.heightTarget = self.objHeight + self.liftThresh
+
+        if self.random_init:
+            obj_pos = np.random.uniform(
+                self.obj_and_goal_space.low,
+                self.obj_and_goal_space.high,
+                size=(self.obj_and_goal_space.low.size),
+            )
+            self.obj_init_pos = obj_pos
+            goal_pos = obj_pos.copy()
+            goal_pos[0] -= 0.18
+            self._state_goal = goal_pos
+
+        self._set_goal_marker(self._state_goal)
+        wall_pos = self.obj_init_pos.copy() - np.array([0.1, 0, 0.12])
+        window_another_pos = self.obj_init_pos.copy() + np.array([0, 0.03, 0])
+        self.sim.model.body_pos[self.model.body_name2id('window')] = self.obj_init_pos
+        self.sim.model.body_pos[self.model.body_name2id('window_another')] = window_another_pos
+        self.sim.model.body_pos[self.model.body_name2id('wall')] = wall_pos
+        self.sim.model.site_pos[self.model.site_name2id('goal')] = self._state_goal
+        self.maxPullDist = 0.2
+        self.target_reward = 1000*self.maxPullDist + 1000*2
+
+        return self._get_obs()
+
+    def _reset_hand(self):
+        for _ in range(10):
+            self.data.set_mocap_pos('mocap', self.hand_init_pos)
+            self.data.set_mocap_quat('mocap', np.array([1, 0, 1, 0]))
+            self.do_simulation([-1,1], self.frame_skip)
+
+        rightFinger, leftFinger = self.get_site_pos('rightEndEffector'), self.get_site_pos('leftEndEffector')
+        self.init_fingerCOM  =  (rightFinger + leftFinger)/2
+        self.reachCompleted = False
+
+    def compute_reward(self, actions, obs):
+        del actions
+
+        obs = obs['state_observation']
+
+        objPos = obs[3:6]
+
+        rightFinger, leftFinger = self.get_site_pos('rightEndEffector'), self.get_site_pos('leftEndEffector')
+        fingerCOM  =  (rightFinger + leftFinger)/2
+
+        pullGoal = self._state_goal
+
+        pullDist = np.abs(objPos[0] - pullGoal[0])
+        reachDist = np.linalg.norm(objPos - fingerCOM)
+
+        self.reachCompleted = reachDist < 0.05
+
+        c1 = 1000
+        c2 = 0.01
+        c3 = 0.001
+        reachRew = -reachDist
+
+        if self.reachCompleted:
+            pullRew = 1000*(self.maxPullDist - pullDist) + c1*(np.exp(-(pullDist**2)/c2) + np.exp(-(pullDist**2)/c3))
+        else:
+            pullRew = 0
+        reward = reachRew + pullRew
+
+        return [reward, reachDist, None, pullDist]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
@@ -1,0 +1,172 @@
+import numpy as np
+from gym.spaces import  Box
+
+from metaworld.envs.env_util import get_asset_full_path
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+
+
+class SawyerWindowOpenEnvV2(SawyerXYZEnv):
+    """
+    Motivation for V2:
+        When V1 scripted policy failed, it was often due to limited path length.
+    Changelog:
+        - (6/15/20) Increased max_path_length from 150 to 200
+    """
+    def __init__(self, random_init=False):
+
+        liftThresh = 0.02
+        hand_low = (-0.5, 0.40, 0.05)
+        hand_high = (0.5, 1, 0.5)
+        obj_low = (-0.1, 0.7, 0.16)
+        obj_high = (0.1, 0.9, 0.16)
+
+        super().__init__(
+            self.model_name,
+            hand_low=hand_low,
+            hand_high=hand_high,
+        )
+
+        self.init_config = {
+            'obj_init_angle': np.array([0.3, ], dtype=np.float32),
+            'obj_init_pos': np.array([-0.1, 0.785, 0.15], dtype=np.float32),
+            'hand_init_pos': np.array([0, 0.6, 0.2], dtype=np.float32),
+        }
+        self.goal = np.array([0.08, 0.785, 0.15])
+        self.obj_init_pos = self.init_config['obj_init_pos']
+        self.obj_init_angle = self.init_config['obj_init_angle']
+        self.hand_init_pos = self.init_config['hand_init_pos']
+
+        goal_low = self.hand_low
+        goal_high = self.hand_high
+
+        self.random_init = random_init
+        self.max_path_length = 200
+        self.liftThresh = liftThresh
+
+        self.action_space = Box(
+            np.array([-1, -1, -1, -1]),
+            np.array([1, 1, 1, 1]),
+        )
+
+        self.obj_and_goal_space = Box(
+            np.array(obj_low),
+            np.array(obj_high),
+        )
+        self.goal_space = Box(np.array(goal_low), np.array(goal_high))
+
+        self.observation_space = Box(
+            np.hstack((self.hand_low, obj_low,)),
+            np.hstack((self.hand_high, obj_high,)),
+        )
+
+        self.reset()
+
+    @property
+    def model_name(self):
+        return get_asset_full_path('sawyer_xyz/sawyer_window_horizontal.xml')
+
+    def step(self, action):
+        self.set_xyz_action(action[:3])
+        self.do_simulation([action[-1], -action[-1]])
+        # The marker seems to get reset every time you do a simulation
+        self._set_goal_marker(self._state_goal)
+        ob = self._get_obs()
+        obs_dict = self._get_obs_dict()
+        reward, reachDist, pickrew, pullDist = self.compute_reward(action, obs_dict)
+        self.curr_path_length += 1
+
+        info = {'reachDist': reachDist, 'goalDist': pullDist, 'epRew' : reward, 'pickRew':pickrew, 'success': float(pullDist <= 0.05)}
+        info['goal'] = self.goal
+
+        return ob, reward, False, info
+
+    def _get_obs(self):
+        hand = self.get_endeff_pos()
+        objPos =  self.get_site_pos('handleOpenStart')
+        flat_obs = np.concatenate((hand, objPos))
+
+        return np.concatenate([flat_obs,])
+
+    def _get_obs_dict(self):
+        hand = self.get_endeff_pos()
+        objPos =  self.get_site_pos('handleOpenStart')
+        flat_obs = np.concatenate((hand, objPos))
+
+        return dict(
+            state_observation=flat_obs,
+            state_desired_goal=self._state_goal,
+            state_achieved_goal=objPos,
+        )
+
+    def _set_goal_marker(self, goal):
+        self.data.site_xpos[self.model.site_name2id('goal')] = (
+            goal[:3]
+        )
+
+    def reset_model(self):
+        self._reset_hand()
+        self._state_goal = self.goal.copy()
+        self.objHeight = self.data.get_geom_xpos('handle')[2]
+        self.heightTarget = self.objHeight + self.liftThresh
+
+        if self.random_init:
+            obj_pos = np.random.uniform(
+                self.obj_and_goal_space.low,
+                self.obj_and_goal_space.high,
+                size=(self.obj_and_goal_space.low.size),
+            )
+            self.obj_init_pos = obj_pos
+            goal_pos = obj_pos.copy()
+            goal_pos[0] += 0.18
+            self._state_goal = goal_pos
+
+        self._set_goal_marker(self._state_goal)
+        wall_pos = self.obj_init_pos.copy() - np.array([-0.1, 0, 0.12])
+        window_another_pos = self.obj_init_pos.copy() + np.array([0.2, 0.03, 0])
+        self.sim.model.body_pos[self.model.body_name2id('window')] = self.obj_init_pos
+        self.sim.model.body_pos[self.model.body_name2id('window_another')] = window_another_pos
+        self.sim.model.body_pos[self.model.body_name2id('wall')] = wall_pos
+        self.sim.model.site_pos[self.model.site_name2id('goal')] = self._state_goal
+        self.maxPullDist = 0.2
+        self.target_reward = 1000*self.maxPullDist + 1000*2
+
+        return self._get_obs()
+
+    def _reset_hand(self):
+        for _ in range(10):
+            self.data.set_mocap_pos('mocap', self.hand_init_pos)
+            self.data.set_mocap_quat('mocap', np.array([1, 0, 1, 0]))
+            self.do_simulation([-1,1], self.frame_skip)
+
+        rightFinger, leftFinger = self.get_site_pos('rightEndEffector'), self.get_site_pos('leftEndEffector')
+        self.init_fingerCOM  =  (rightFinger + leftFinger)/2
+        self.reachCompleted = False
+
+    def compute_reward(self, actions, obs):
+        del actions
+
+        obs = obs['state_observation']
+
+        objPos = obs[3:6]
+
+        rightFinger, leftFinger = self.get_site_pos('rightEndEffector'), self.get_site_pos('leftEndEffector')
+        fingerCOM  =  (rightFinger + leftFinger)/2
+
+        pullGoal = self._state_goal
+
+        pullDist = np.abs(objPos[0] - pullGoal[0])
+        reachDist = np.linalg.norm(objPos - fingerCOM)
+
+        self.reachCompleted = reachDist < 0.05
+
+        c1 = 1000
+        c2 = 0.01
+        c3 = 0.001
+        reachRew = -reachDist
+        if self.reachCompleted:
+            pullRew = 1000*(self.maxPullDist - pullDist) + c1*(np.exp(-(pullDist**2)/c2) + np.exp(-(pullDist**2)/c3))
+        else:
+            pullRew = 0
+        reward = reachRew + pullRew
+
+        return [reward, reachDist, None, pullDist]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
@@ -9,7 +9,7 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
     """
     Motivation for V2:
         When V1 scripted policy failed, it was often due to limited path length.
-    Changelog:
+    Changelog from V1 to V2:
         - (6/15/20) Increased max_path_length from 150 to 200
     """
     def __init__(self, random_init=False):

--- a/metaworld/policies/__init__.py
+++ b/metaworld/policies/__init__.py
@@ -1,0 +1,7 @@
+from metaworld.policies.sawyer_window_open_v2_policy import SawyerWindowOpenV2Policy
+from metaworld.policies.sawyer_window_close_v2_policy import SawyerWindowCloseV2Policy
+
+__all__ = [
+    'SawyerWindowOpenV2Policy',
+    'SawyerWindowCloseV2Policy'
+]

--- a/metaworld/policies/policy.py
+++ b/metaworld/policies/policy.py
@@ -4,6 +4,23 @@ import warnings
 import numpy as np
 
 
+def assert_fully_parsed(func):
+    """Decorator function to ensure observations are fully parsed
+
+    Args:
+        func (Callable): The function to check
+
+    Returns:
+        (Callable): The input function, decorated to assert full parsing
+    """
+    def inner(obs):
+        obs_dict = func(obs)
+        assert len(obs) == sum([len(i) for i in obs_dict.values()]), \
+            'Observation not fully parsed'
+        return obs_dict
+    return inner
+
+
 def move(from_xyz, to_xyz, p):
     """Computes action components that help move from 1 position to another
 

--- a/metaworld/policies/sawyer_window_close_v2_policy.py
+++ b/metaworld/policies/sawyer_window_close_v2_policy.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from metaworld.policies.action import Action
+from metaworld.policies.policy import Policy, assert_fully_parsed, move
+
+
+class SawyerWindowCloseV2Policy(Policy):
+
+    @staticmethod
+    @assert_fully_parsed
+    def parse_obs(obs):
+        return {
+            'hand_xyz': obs[:3],
+            'wndw_xyz': obs[3:],
+        }
+
+    def get_action(self, obs):
+        o_d = self.parse_obs(obs)
+
+        action = Action({
+            'delta_pos': np.arange(3),
+            'grab_pow': 3
+        })
+
+        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self.desired_xyz(o_d), p=25.)
+        action['grab_pow'] = 1.
+
+        return action.array
+
+    @staticmethod
+    def desired_xyz(o_d):
+        pos_curr = o_d['hand_xyz']
+        pos_wndw = o_d['wndw_xyz']
+        pos_wndw += np.array([+0.03, -0.03, -0.1])
+
+        if np.linalg.norm(pos_curr[:2] - pos_wndw[:2]) > 0.04:
+            return pos_wndw + np.array([0., 0., 0.3])
+        elif abs(pos_curr[2] - pos_wndw[2]) > 0.02:
+            return pos_wndw
+        else:
+            return pos_wndw + np.array([-0.1, 0., 0.])

--- a/metaworld/policies/sawyer_window_open_v2_policy.py
+++ b/metaworld/policies/sawyer_window_open_v2_policy.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from metaworld.policies.action import Action
+from metaworld.policies.policy import Policy, assert_fully_parsed, move
+
+
+class SawyerWindowOpenV2Policy(Policy):
+
+    @staticmethod
+    @assert_fully_parsed
+    def parse_obs(obs):
+        return {
+            'hand_xyz': obs[:3],
+            'wndw_xyz': obs[3:],
+        }
+
+    def get_action(self, obs):
+        o_d = self.parse_obs(obs)
+
+        action = Action({
+            'delta_pos': np.arange(3),
+            'grab_pow': 3
+        })
+
+        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self.desired_xyz(o_d), p=25.)
+        action['grab_pow'] = 1.
+
+        return action.array
+
+    @staticmethod
+    def desired_xyz(o_d):
+        pos_curr = o_d['hand_xyz']
+        pos_wndw = o_d['wndw_xyz']
+        pos_wndw += np.array([-0.03, -0.03, -0.1])
+
+        if np.linalg.norm(pos_curr[:2] - pos_wndw[:2]) > 0.04:
+            return pos_wndw + np.array([0., 0., 0.3])
+        elif abs(pos_curr[2] - pos_wndw[2]) > 0.02:
+            return pos_wndw
+        else:
+            return pos_wndw + np.array([0.1, 0., 0.])

--- a/tests/integration/test_memory_usage.py
+++ b/tests/integration/test_memory_usage.py
@@ -3,7 +3,7 @@ import memory_profiler
 import pytest
 
 from metaworld.benchmarks import ML45
-from metaworld.envs.mujoco.env_dict import ALL_ENVIRONMENTS
+from metaworld.envs.mujoco.env_dict import ALL_V1_ENVIRONMENTS
 from tests.helpers import step_env
 
 
@@ -23,7 +23,7 @@ def build_and_step_all(classes):
 @pytest.fixture(scope='module')
 def mt50_usage():
     profile = {}
-    for env_cls in ALL_ENVIRONMENTS.values():
+    for env_cls in ALL_V1_ENVIRONMENTS.values():
         target = (build_and_step, [env_cls], {})
         memory_usage = memory_profiler.memory_usage(target)
         profile[env_cls] = max(memory_usage)
@@ -32,7 +32,7 @@ def mt50_usage():
 
 
 @pytest.mark.skip
-@pytest.mark.parametrize('env_cls', ALL_ENVIRONMENTS.values())
+@pytest.mark.parametrize('env_cls', ALL_V1_ENVIRONMENTS.values())
 def test_max_memory_usage(env_cls, mt50_usage):
     # No env should use more  than 250MB
     #
@@ -45,9 +45,9 @@ def test_max_memory_usage(env_cls, mt50_usage):
 @pytest.mark.skip
 def test_avg_memory_usage():
     # average usage no greater than 60MB/env
-    target = (build_and_step_all, [ALL_ENVIRONMENTS.values()], {})
+    target = (build_and_step_all, [ALL_V1_ENVIRONMENTS.values()], {})
     usage = memory_profiler.memory_usage(target)
-    average = max(usage) / len(ALL_ENVIRONMENTS)
+    average = max(usage) / len(ALL_V1_ENVIRONMENTS)
     assert average < 60
 
 

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_sawyer_parameterized.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_sawyer_parameterized.py
@@ -4,11 +4,11 @@ import numpy as np
 
 from tests.helpers import step_env
 
-from metaworld.envs.mujoco.env_dict import ALL_ENVIRONMENTS, _hard_mode_args_kwargs
+from metaworld.envs.mujoco.env_dict import ALL_V1_ENVIRONMENTS, _hard_mode_args_kwargs
 
-@pytest.fixture(scope='module', params=list(ALL_ENVIRONMENTS.keys()))
+@pytest.fixture(scope='module', params=list(ALL_V1_ENVIRONMENTS.keys()))
 def env(request):
-    env_cls = ALL_ENVIRONMENTS[request.param]
+    env_cls = ALL_V1_ENVIRONMENTS[request.param]
     env_args_kwargs = _hard_mode_args_kwargs(env_cls, request.param)
     env_args = env_args_kwargs['args']
     env_kwargs = env_args_kwargs['kwargs']

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
@@ -1,0 +1,53 @@
+import pytest
+
+from metaworld.envs.mujoco.env_dict import ALL_V1_ENVIRONMENTS, ALL_V2_ENVIRONMENTS
+from metaworld.policies import *
+from tests.metaworld.envs.mujoco.sawyer_xyz.utils import check_success
+
+
+test_cases = [
+    # name, policy, action noise pct, success rate, env kwargs
+    ['window-open-v1', SawyerWindowOpenV2Policy(), .0, 0.86, {}],
+    ['window-open-v1', SawyerWindowOpenV2Policy(), .1, 0.85, {}],
+    ['window-open-v2', SawyerWindowOpenV2Policy(), 0., 0.97, {}],
+    ['window-open-v2', SawyerWindowOpenV2Policy(), .1, 0.97, {}],
+    ['window-close-v1', SawyerWindowCloseV2Policy(), .0, 0.44, {}],
+    ['window-close-v1', SawyerWindowCloseV2Policy(), .1, 0.44, {}],
+    ['window-close-v2', SawyerWindowCloseV2Policy(), 0., 0.98, {}],
+    ['window-close-v2', SawyerWindowCloseV2Policy(), .1, 0.98, {}],
+]
+
+ALL_ENVS = {**ALL_V1_ENVIRONMENTS, **ALL_V2_ENVIRONMENTS}
+
+for row in test_cases:
+    # row[-1] contains env kwargs. This instantiates an env with those kwargs,
+    # then replaces row[-1] with the env object (kwargs are no longer needed)
+    row[-1] = ALL_ENVS[row[0]](random_init=True, **row[-1])
+    # now remove env names from test_data, as they aren't needed in parametrize
+    row.pop(0)
+
+
+@pytest.mark.parametrize(
+    'policy,act_noise_pct,expected_success_rate,env',
+    test_cases
+)
+def test_scripted_policy(env, policy, act_noise_pct, expected_success_rate, iters=1000):
+    """Tests whether a given policy solves an environment in a stateless manner
+    Args:
+        env (metaworld.envs.MujocoEnv): Environment to test
+        policy (metaworld.policies.policy.Policy): Policy that's supposed to
+            succeed in env
+        act_noise_pct (float): Decimal value indicating std deviation of the
+            noise as a % of action space
+        expected_success_rate (float): Decimal value indicating % of runs that
+            must be successful
+        iters (int): How many times the policy should be tested
+    """
+    assert len(vars(policy)) == 0, \
+        '{} has state variable(s)'.format(policy.__class__.__name__)
+
+    successes = 0
+    for i in range(iters):
+        successes += float(check_success(env, policy, act_noise_pct)[0])
+
+    assert successes >= expected_success_rate * iters

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/utils.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/utils.py
@@ -1,14 +1,21 @@
-def check_success(env, policy, render=False):
-    """Tests whether a given policy solves an environment
+import numpy as np
 
+
+def check_success(env, policy, act_noise_pct, render=False):
+    """Tests whether a given policy solves an environment
     Args:
         env (metaworld.envs.MujocoEnv): Environment to test
-        policy (metaworld.policies.policies.Policy): Policy that's supposed to succeed in env
+        policy (metaworld.policies.policies.Policy): Policy that's supposed to
+            succeed in env
+        act_noise_pct (float): Decimal value indicating std deviation of the
+            noise as a % of action space
         render (bool): Whether to render the env in a GUI
-
     Returns:
         (bool, int): Success flag, Trajectory length
     """
+    action_space_ptp = env.action_space.high - env.action_space.low
+
+    env.reset()
     env.reset_model()
     o = env.reset()
 
@@ -16,8 +23,8 @@ def check_success(env, policy, render=False):
     done = False
     success = False
     while not success and not done:
-        assert len(o) == sum([len(i) for i in policy.parse_obs(o).values()]), 'Observation not fully parsed'
         a = policy.get_action(o)
+        a = np.random.normal(a, act_noise_pct * action_space_ptp)
         try:
             o, r, done, info = env.step(a)
 
@@ -28,7 +35,6 @@ def check_success(env, policy, render=False):
             success |= bool(info['success'])
 
         except ValueError:
-            env.reset()
-            done = True
+            break
 
     return success, t

--- a/tests/metaworld/envs/test_multitask_env.py
+++ b/tests/metaworld/envs/test_multitask_env.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from metaworld.benchmarks import ML10, ML45
-from metaworld.envs.mujoco.env_dict import HARD_MODE_CLS_DICT, MEDIUM_MODE_CLS_DICT, MEDIUM_MODE_ARGS_KWARGS, ALL_ENVIRONMENTS
+from metaworld.envs.mujoco.env_dict import HARD_MODE_CLS_DICT, MEDIUM_MODE_CLS_DICT, MEDIUM_MODE_ARGS_KWARGS, ALL_V1_ENVIRONMENTS
 from metaworld.envs.mujoco.multitask_env import MultiClassMultiTaskEnv
 from metaworld.envs.mujoco.sawyer_xyz import SawyerReachPushPickPlaceEnv
 from metaworld.envs.mujoco.sawyer_xyz import SawyerReachPushPickPlaceWallEnv
@@ -12,7 +12,7 @@ HARD_MODE_LIST = (list(HARD_MODE_CLS_DICT['train'].values()) +
                   list(HARD_MODE_CLS_DICT['test'].values()))
 
 
-@pytest.mark.parametrize('env_cls', ALL_ENVIRONMENTS.values())
+@pytest.mark.parametrize('env_cls', ALL_V1_ENVIRONMENTS.values())
 def test_single_env_multi_goals_discrete(env_cls):
     env_cls_dict = {'wrapped': env_cls}
     env_args_kwargs = {'wrapped': dict(args=[], kwargs={'task_id' : 1})}
@@ -228,8 +228,8 @@ def test_action_space():
     assert multi_task_env.action_space.shape == (4, )
 
 
-@pytest.mark.parametrize('task_name', list(ALL_ENVIRONMENTS.keys())[:10])
+@pytest.mark.parametrize('task_name', list(ALL_V1_ENVIRONMENTS.keys())[:10])
 def test_static_task_ids(task_name):
     env = ML45.from_task(task_name)
-    assert env.active_task == list(ALL_ENVIRONMENTS.keys()).index(task_name)
+    assert env.active_task == list(ALL_V1_ENVIRONMENTS.keys()).index(task_name)
 


### PR DESCRIPTION
This PR adds scripted policies for the window-open and window-close environments. The policies achieve some success on v1 environments, but increasing `max_path_length` to 200 (see v2 envs) resulted in much higher success rates. I also addressed all of @ryanjulian's comments from #92, so ideally we would get this merged and then rebase the other scripted policies off of this.