### PR TITLE
Remove opencv and add numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ required = [
     # Please keep alphabetized
     'gym>=0.15.4',
     'mujoco-py<2.1,>=2.0',
-    'opencv-python>=4.1.0.25',
+    'numpy>=1.18',
 ]
 
 


### PR DESCRIPTION
Correct me if I'm wrong, but as far as I can tell, we had absolutely no need for opencv and its only purpose was to vicariously obtain numpy.