### PR TITLE
Add goal pos to all envs and adjust policies accordingly

### DIFF
--- a/metaworld/envs/mujoco/mujoco_env.py
+++ b/metaworld/envs/mujoco/mujoco_env.py
@@ -12,6 +12,19 @@ try:
 except ImportError as e:
     raise error.DependencyNotInstalled("{}. (HINT: you need to install mujoco_py, and also perform the setup instructions here: https://github.com/openai/mujoco-py/.)".format(e))
 
+
+def _assert_task_is_set(func):
+    def inner(*args, **kwargs):
+        env = args[0]
+        if not env._task_is_set:
+            raise RuntimeError(
+                'You must call env.set_task before using env.'
+                + func.__name__
+            )
+        return func(*args, **kwargs)
+    return inner
+
+
 DEFAULT_SIZE = 500
 
 class MujocoEnv(gym.Env, abc.ABC):
@@ -44,6 +57,22 @@ class MujocoEnv(gym.Env, abc.ABC):
 
         self.seed()
 
+        self._task = None
+
+    @property
+    def _task_is_set(self):
+        return not (self._task is None)
+
+    def set_task(self, is_partially_observable):
+        """Configures the environment for stepping. This must be called before
+        env.step() or env.reset()
+
+        Args:
+            is_partially_observable (bool): Specifies whether the environment
+                is fully observable
+        """
+        self._task = {'partially_observable': is_partially_observable}
+
     def seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
         return [seed]
@@ -64,6 +93,7 @@ class MujocoEnv(gym.Env, abc.ABC):
         """
         pass
 
+    @_assert_task_is_set
     def reset(self):
         self.sim.reset()
         ob = self.reset_model()

--- a/metaworld/envs/mujoco/multitask_env.py
+++ b/metaworld/envs/mujoco/multitask_env.py
@@ -34,7 +34,7 @@ class MultiClassMultiTaskEnv(gym.Env):
         # hardcoded so we don't have to iterate over all envs and check the maximum
         # this is the maximum observation dimension after augmenting observation
         # e.g. adding goal
-        self._max_obs_dim = 9
+        self._max_obs_dim = 12
         self._env_discrete_index = {}
         for task, env_cls in task_env_cls_dict.items():
             task_args = task_args_kwargs[task]['args']
@@ -139,6 +139,8 @@ class MultiClassMultiTaskEnv(gym.Env):
             return tasks
 
     def step(self, action):
+        self.active_env.set_task(is_partially_observable=False)
+
         obs, reward, done, info = self.active_env.step(action)
         obs = self._augment_observation(obs)
         info['task_name'] = self._task_names[self._active_task]
@@ -158,6 +160,8 @@ class MultiClassMultiTaskEnv(gym.Env):
         return obs
 
     def reset(self, **kwargs):
+        self.active_env.set_task(is_partially_observable=False)
+
         obs = self._augment_observation(self.active_env.reset(**kwargs))
         return obs
 

--- a/metaworld/envs/mujoco/sawyer_xyz/base.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/base.py
@@ -74,6 +74,7 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
             mocap_high=None,
             action_scale=1./100,
             action_rot_scale=1.,
+            include_goal_in_obs=True,
     ):
         super().__init__(model_name, frame_skip=frame_skip)
         self.action_scale = action_scale
@@ -97,6 +98,8 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
         self.active_discrete_goal = None
 
         self._state_goal = None  # OVERRIDE ME
+        self.include_goal_in_obs = include_goal_in_obs
+
 
     def set_xyz_action(self, action):
         action = np.clip(action, -1, 1)
@@ -181,13 +184,16 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
         pos_obj = self._get_pos_objects()
         pos_goal = self._get_pos_goal()
 
+        if not self.include_goal_in_obs:
+            pos_goal = np.zeros_like(pos_goal)
+
         return np.hstack((pos_hand, pos_obj, pos_goal))
 
     def _get_obs_dict(self):
         obs = self._get_obs()
         return dict(
             state_observation=obs,
-            state_desired_goal=obs[-3:],
+            state_desired_goal=self._get_pos_goal(),
             state_achieved_goal=obs[3:-3],
         )
 

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_assembly_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_assembly_peg.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerNutAssemblyEnv(SawyerXYZEnv):
@@ -38,11 +38,6 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         goal_low = np.array(goal_low)
         goal_high = np.array(goal_high)
         self.obj_and_goal_space = Box(
@@ -52,15 +47,15 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_assembly_peg.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -74,22 +69,13 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
         info['goal'] = self.goal
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        graspPos =  self.data.get_geom_xpos('RoundNut-8')
-        flat_obs = np.concatenate((hand, graspPos))
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('RoundNut-8')
 
     def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        graspPos =  self.data.get_geom_xpos('RoundNut-8')
-        objPos = self.get_body_com('RoundNut')
-        flat_obs = np.concatenate((hand, graspPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+        obs_dict = super()._get_obs_dict()
+        obs_dict['state_achieved_goal'] = self.get_body_com('RoundNut')
+        return obs_dict
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('pegTop')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerBasketballEnv(SawyerXYZEnv):
@@ -38,25 +38,21 @@ class SawyerBasketballEnv(SawyerXYZEnv):
         self.max_path_length = 150
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_basketball.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,22 +66,8 @@ class SawyerBasketballEnv(SawyerXYZEnv):
         info['goal'] = self.goal
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerBasketballEnvV2(SawyerXYZEnv):
@@ -48,10 +48,6 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
         self.max_path_length = 150
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -61,12 +57,12 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_low, obj_low, goal_low)),
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_basketball.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_basketball_v2.py
@@ -11,6 +11,8 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
         V1 was difficult to solve because the observation didn't say where
         to drop the ball (the hoop's location).
     Changelog from V1 to V2:
+        - (7/7/20) Removed 1 element vector. Replaced with 3 element position
+            of the hoop (for consistency with other environments)
         - (6/16/20) Added a 1 element vector to the observation. This vector
             points from the end effector to the hoop in the X direction.
             i.e. (self._state_goal - pos_hand)[0]
@@ -54,11 +56,10 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
         )
-        hand_to_goal_max_x = self.hand_high[0] - np.array(goal_low)[0]
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, -hand_to_goal_max_x)),
-            np.hstack((self.hand_high, obj_high, hand_to_goal_max_x)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
         self.reset()
 
@@ -79,20 +80,8 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
         info['goal'] = self.goal
         return ob, reward, False, info
 
-    def _get_obs(self):
-        pos_hand = self.get_endeff_pos()
-        pos_obj = self.data.get_geom_xpos('objGeom')
-        hand_to_goal = (self._state_goal - pos_hand)[0]
-
-        flat_obs = np.hstack((pos_hand, pos_obj, hand_to_goal))
-        return np.concatenate([flat_obs, ])
-
-    def _get_obs_dict(self):
-        return dict(
-            state_observation=self._get_obs(),
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_bin_picking.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_bin_picking.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerBinPickingEnv(SawyerXYZEnv):
@@ -38,11 +38,6 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.hand_and_obj_space = Box(
             np.hstack((self.hand_low, obj_low)),
             np.hstack((self.hand_high, obj_high)),
@@ -56,16 +51,15 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
         self.goal_space = Box(goal_low, goal_high)
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_bin_picking.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -80,22 +74,8 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_xyz(self, goal):
         del goal  # rjulian: ??? What?

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_box_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_box_close.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerBoxCloseEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -49,16 +44,15 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_box.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,21 +66,8 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
         info['goal'] = self.goal
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle').copy()
-        flat_obs = np.concatenate((hand, objPos))
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle').copy()
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('handle').copy()
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerButtonPressEnv(SawyerXYZEnv):
@@ -33,11 +33,6 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -45,16 +40,15 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_button_press.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -67,22 +61,8 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
         info['goal'] = self.goal
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('buttonStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -47,16 +42,15 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_button_press_topdown.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,21 +64,8 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('buttonStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_topdown_wall.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
@@ -35,27 +35,21 @@ class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_button_press_topdown_wall.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -69,22 +63,8 @@ class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('buttonStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_button_press_wall.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerButtonPressWallEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -47,16 +42,15 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
 
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_button_press_wall.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,22 +64,8 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('buttonStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_button.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_button.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerCoffeeButtonEnv(SawyerXYZEnv):
@@ -36,27 +36,21 @@ class SawyerCoffeeButtonEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_coffee.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -71,22 +65,8 @@ class SawyerCoffeeButtonEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('buttonStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('buttonStart')]
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('coffee_goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_pull.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 class SawyerCoffeePullEnv(SawyerXYZEnv):
 
@@ -33,11 +33,6 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
         self.obj_init_angle = self.init_config['obj_init_angle']
         self.hand_init_pos = self.init_config['hand_init_pos']
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -45,16 +40,15 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
 
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_coffee.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,22 +64,8 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('mug_goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_coffee_push.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerCoffeePushEnv(SawyerXYZEnv):
@@ -36,27 +36,21 @@ class SawyerCoffeePushEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_coffee.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -71,22 +65,8 @@ class SawyerCoffeePushEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('coffee_goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_dial_turn.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_dial_turn.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerDialTurnEnv(SawyerXYZEnv):
@@ -33,10 +33,6 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
         goal_high = self.hand_high
 
         self.max_path_length = 150
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
 
         self.obj_and_goal_space = Box(
             np.array(obj_low),
@@ -44,16 +40,15 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_dial.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -68,12 +63,8 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('dialStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('dialStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_disassemble_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_disassemble_peg.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerNutDisassembleEnv(SawyerXYZEnv):
@@ -37,11 +37,6 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -49,16 +44,15 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_assembly_peg.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -73,24 +67,13 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        graspPos =  self.get_site_pos('RoundNut-8')
-        flat_obs = np.concatenate((hand, graspPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('RoundNut-8')
 
     def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        graspPos =  self.get_site_pos('RoundNut-8')
-        objPos = self.get_body_com('RoundNut')
-        flat_obs = np.concatenate((hand, graspPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+        obs_dict = super()._get_obs_dict()
+        obs_dict['state_achieved_goal'] = self.get_body_com('RoundNut')
+        return obs_dict
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('pegTop')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerDoorEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerDoorEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -48,18 +43,17 @@ class SawyerDoorEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.door_angle_idx = self.model.get_joint_qpos_addr('doorjoint')
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_door_pull.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -74,23 +68,8 @@ class SawyerDoorEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle').copy()
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle').copy()
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('handle').copy()
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_close.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv, _assert_task_is_set
 
 
 class SawyerDoorCloseEnv(SawyerDoorEnv):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_lock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_lock.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerDoorLockEnv(SawyerXYZEnv):
@@ -35,27 +35,21 @@ class SawyerDoorLockEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_door_lock.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,12 +64,8 @@ class SawyerDoorLockEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('lockStartLock')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('lockStartLock')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal_lock')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_unlock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_door_unlock.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerDoorUnlockEnv(SawyerXYZEnv):
@@ -33,11 +33,6 @@ class SawyerDoorUnlockEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -45,16 +40,15 @@ class SawyerDoorUnlockEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_door_lock.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -68,12 +62,8 @@ class SawyerDoorUnlockEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('lockStartUnlock')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('lockStartUnlock')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal_unlock')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_close.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerDrawerCloseEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -48,16 +43,15 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_drawer.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,21 +66,8 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle')
-        flat_obs = np.concatenate((hand, objPos))
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('handle')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_drawer_open.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerDrawerOpenEnv(SawyerXYZEnv):
@@ -37,11 +37,6 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
         self.random_init = random_init
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -49,16 +44,15 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_drawer.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -73,23 +67,13 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('handle').copy()
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('handle').copy()
 
     def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  (self.get_site_pos('handleStart').copy() + self.data.get_geom_xpos('drawer_wall2').copy()) / 2
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+        obs_dict = super()._get_obs_dict()
+        obs_dict['state_achieved_goal'] = (self.get_site_pos('handleStart').copy() + self.data.get_geom_xpos('drawer_wall2').copy()) / 2
+        return obs_dict
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_close.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerFaucetCloseEnv(SawyerXYZEnv):
@@ -34,11 +34,6 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -46,16 +41,15 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_faucet.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -69,12 +63,8 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('handleStartClose')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('handleStartClose')
 
     def _set_goal_marker(self, goal):
         """

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_faucet_open.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerFaucetOpenEnv(SawyerXYZEnv):
@@ -33,11 +33,6 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -45,16 +40,15 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_faucet.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -69,12 +63,8 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('handleStartOpen')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('handleStartOpen')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal_open')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_hammer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_hammer.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHammerEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerHammerEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -47,16 +42,15 @@ class SawyerHammerEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_hammer.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -71,25 +65,19 @@ class SawyerHammerEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        hammerPos = self.get_body_com('hammer').copy()
-        flat_obs = np.concatenate((hand, hammerPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_body_com('hammer').copy()
 
     def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        hammerPos = self.get_body_com('hammer').copy()
-        hammerHeadPos = self.data.get_geom_xpos('hammerHead').copy()
-        objPos =  self.data.site_xpos[self.model.site_name2id('screwHead')]
-        flat_obs = np.concatenate((hand, hammerPos, hammerHeadPos, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+        obs_dict = super()._get_obs_dict()
+        obs_dict['state_observation'] = np.concatenate((
+            self.get_endeff_pos(),
+            self.get_body_com('hammer').copy(),
+            self.data.get_geom_xpos('hammerHead').copy(),
+            self.data.site_xpos[self.model.site_name2id('screwHead')]
+        ))
+        obs_dict['state_achieved_goal'] = self.data.site_xpos[self.model.site_name2id('screwHead')]
+        return obs_dict
 
     def _set_hammer_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_hand_insert.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_hand_insert.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHandInsertEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
 
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -47,16 +42,15 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_table_with_hole.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,22 +66,8 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHandlePressEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -47,16 +42,15 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_handle_press.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -71,22 +65,8 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('handleStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_press_side.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHandlePressSideEnv(SawyerXYZEnv):
@@ -34,11 +34,6 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -46,16 +41,15 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_handle_press_sideway.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,22 +64,8 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('handleStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHandlePullEnv(SawyerXYZEnv):
@@ -34,11 +34,6 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -46,16 +41,15 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_handle_press.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,22 +64,8 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('handleStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_handle_pull_side.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHandlePullSideEnv(SawyerXYZEnv):
@@ -34,11 +34,6 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -46,16 +41,15 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_handle_press_sideway.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,22 +64,8 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.site_xpos[self.model.site_name2id('handleStart')]
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.site_xpos[self.model.site_name2id('handleStart')]
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerLeverPullEnv(SawyerXYZEnv):
@@ -34,11 +34,6 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
         self.random_init = random_init
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -46,16 +41,15 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_lever_pull.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -70,12 +64,8 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('leverStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('leverStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull_v2.py
@@ -11,6 +11,8 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
         V1 was impossible to solve because the lever would have to be pulled
         through the table in order to reach the target location.
     Changelog from V1 to V2:
+        - (7/7/20) Added 3 element lever position to the observation
+            (for consistency with other environments)
         - (6/23/20) In `reset_model`, changed `final_pos[2] -= .17` to `+= .17`
             This ensures that the target point is above the table.
     """
@@ -53,8 +55,8 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.reset()
@@ -77,12 +79,8 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.get_site_pos('leverStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
+    def _get_pos_objects(self):
+        return self.get_site_pos('leverStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_lever_pull_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerLeverPullEnvV2(SawyerXYZEnv):
@@ -43,11 +43,6 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
         self.random_init = random_init
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -59,12 +54,11 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_lever_pull.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPegInsertionSideEnv(SawyerXYZEnv):
@@ -41,11 +41,6 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
 
         self.hand_init_pos = np.array(hand_init_pos)
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -53,16 +48,15 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_peg_insertion_side.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -77,22 +71,8 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_body_com('peg')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_body_com('peg')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.get_body_com('peg')
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_insertion_side_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
@@ -55,11 +55,6 @@ class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
 
         self.hand_init_pos = np.array(hand_init_pos)
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -71,12 +66,11 @@ class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_peg_insertion_side.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_unplug_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_peg_unplug_side.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import  Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPegUnplugSideEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -48,16 +43,15 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_peg_unplug_side.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -73,23 +67,8 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('pegEnd')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('pegEnd')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.get_site_pos('pegEnd')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_out_of_hole.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_out_of_hole.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
@@ -38,11 +38,6 @@ class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
         self.max_path_length = 200
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -50,16 +45,15 @@ class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_pick_out_of_hole.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -75,22 +69,8 @@ class SawyerPickOutOfHoleEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPickPlaceEnvV2(SawyerXYZEnv):
@@ -50,11 +50,6 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -67,12 +62,12 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_pick_place_v2.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_v2.py
@@ -11,6 +11,8 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         V1 was very difficult to solve because the observation didn't say where
         to move after picking up the puck.
     Changelog from V1 to V2:
+        - (7/7/20) Removed 3 element vector. Replaced with 3 element position
+            of the goal (for consistency with other environments)
         - (6/15/20) Added a 3 element vector to the observation. This vector
             points from the end effector to the goal coordinate.
             i.e. (self._state_goal - pos_hand)
@@ -60,8 +62,8 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, np.array(goal_low) - self.hand_high)),
-            np.hstack((self.hand_high, obj_high, self.hand_high - np.array(goal_low))),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.num_resets = 0
@@ -95,20 +97,8 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         self.curr_path_length += 1
         return ob, rew, False, info
 
-    def _get_obs(self):
-        pos_hand = self.get_endeff_pos()
-        pos_obj = self.data.get_geom_xpos('objGeom')
-        hand_to_goal = self._state_goal - pos_hand
-
-        flat_obs = np.concatenate((pos_hand, pos_obj, hand_to_goal))
-        return np.concatenate([flat_obs, ])
-
-    def _get_obs_dict(self):
-        return dict(
-            state_observation=self._get_obs(),
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = goal[:3]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_wall_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
@@ -19,7 +19,7 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         - (6/24/20) Separated pick-place-wall into from
           reach-push-pick-place-wall.
     """
-    def __init__(self, random_init=False, task_type='pick_place'):
+    def __init__(self, random_init=False):
 
         liftThresh = 0.04
         goal_low = (-0.05, 0.85, 0.05)
@@ -51,11 +51,6 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -68,12 +63,12 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_pick_place_wall_v2.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_pick_place_wall_v2.py
@@ -11,6 +11,8 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         V1 was difficult to solve because the observation didn't say where
         to move after picking up the puck.
     Changelog from V1 to V2:
+        - (7/7/20) Removed 3 element vector. Replaced with 3 element position
+            of the goal (for consistency with other environments)
         - (6/24/20) Added a 3 element vector to the observation. This vector
             points from the end effector to the goal coordinate.
             i.e. (self._state_goal - pos_hand)
@@ -61,8 +63,8 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, np.array(goal_low) - self.hand_high)),
-            np.hstack((self.hand_high, obj_high,self.hand_high - np.array(goal_low))),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.num_resets = 0
@@ -96,20 +98,8 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         self.curr_path_length +=1
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        obj_pos =  self.data.get_geom_xpos('objGeom')
-        hand_to_goal = self._state_goal - hand
-
-        flat_obs = np.concatenate((hand, obj_pos, hand_to_goal))
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        return dict(
-            state_observation=self._get_obs(),
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = goal[:3]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPlateSlideEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -48,16 +43,15 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_plate_slide.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,22 +66,8 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPlateSlideBackEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -48,16 +43,15 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_plate_slide.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -73,22 +67,8 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -48,16 +43,15 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_plate_slide_sideway.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -73,22 +67,8 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
@@ -47,11 +47,6 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -63,12 +58,11 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_plate_slide_sideway.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_back_side_v2.py
@@ -14,6 +14,8 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
         very difficult as soon as noise is introduced to the action space
         (success rate dropped from 100% to 20%).
     Changelog from V1 to V2:
+        - (7/7/20) Added 3 element cabinet position to the observation
+            (for consistency with other environments)
         - (6/22/20) Cabinet now sits on ground, instead of .02 units above it
     """
     def __init__(self, random_init=False):
@@ -57,8 +59,8 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.reset()
@@ -88,21 +90,14 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos = self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs, ])
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos = self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
         return dict(
-            state_observation=flat_obs,
+            state_observation=self._get_obs(),
             state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
+            state_achieved_goal=self._get_pos_objects(),
         )
 
     def _set_goal_marker(self, goal):

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_side.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPlateSlideSideEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -48,16 +43,15 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_plate_slide_sideway.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,22 +66,8 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_objCOM_marker(self):
         objPos =  self.data.get_geom_xpos('handle')

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPlateSlideEnvV2(SawyerXYZEnv):
@@ -46,11 +46,6 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -62,12 +57,11 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_plate_slide.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_plate_slide_v2.py
@@ -11,6 +11,8 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
         V1 was very difficult to solve because the observation didn't say where
         the cabinet was along the X axis
     Changelog from V1 to V2:
+        - (7/7/20) Removed 1 element vector. Replaced with 3 element position
+            of the cabinet (for consistency with other environments)
         - (6/22/20) Added a 1 element vector to the observation. This vector
             points from the end effector to the cabinet in the X direction.
             i.e. (self._state_goal - pos_hand)[0]
@@ -54,10 +56,10 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
             np.hstack((obj_high, goal_high)),
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
-        hand_to_goal_max_x = self.hand_high[0] - np.array(goal_low)[0]
+
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, -hand_to_goal_max_x)),
-            np.hstack((self.hand_high, obj_high, hand_to_goal_max_x)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.reset()
@@ -86,20 +88,8 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        pos_hand = self.get_endeff_pos()
-        pos_obj = self.data.get_geom_xpos('objGeom')
-        pos_cabinet = (self._state_goal - pos_hand)[0]
-
-        flat_obs = np.hstack((pos_hand, pos_obj, pos_cabinet))
-        return np.concatenate([flat_obs, ])
-
-    def _get_obs_dict(self):
-        return dict(
-            state_observation=self._get_obs(),
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_back.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPushBackEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerPushBackEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -47,16 +42,15 @@ class SawyerPushBackEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low)),
-            np.hstack((self.hand_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_push_back.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,22 +66,8 @@ class SawyerPushBackEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPushEnvV2(SawyerXYZEnv):
@@ -67,12 +67,12 @@ class SawyerPushEnvV2(SawyerXYZEnv):
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_push_v2.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -189,7 +189,7 @@ class SawyerPushEnvV2(SawyerXYZEnv):
         c3 = 0.001
         reach_dist = np.linalg.norm(finger_center - pos_obj)
         reach_rew = -reach_dist
-        
+
         push_dist = np.linalg.norm(pos_obj[:2] - goal[:2])
         if reach_dist < 0.05:
             push_rew = c1 * (self.maxPushDist - push_dist) + \

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_push_wall_v2.py
@@ -3,7 +3,7 @@
 import numpy as np
 from gym.spaces import Box
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPushWallEnvV2(SawyerXYZEnv):
@@ -37,6 +37,7 @@ class SawyerPushWallEnvV2(SawyerXYZEnv):
             self.model_name,
             hand_low=hand_low,
             hand_high=hand_high,
+            include_goal_in_obs=True,
         )
 
         self.init_config = {
@@ -55,11 +56,6 @@ class SawyerPushWallEnvV2(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -72,12 +68,12 @@ class SawyerPushWallEnvV2(SawyerXYZEnv):
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_push_wall_v2.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
@@ -51,11 +51,6 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -63,17 +58,17 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_reach_push_pick_and_place.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -96,22 +91,8 @@ class SawyerReachPushPickPlaceEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal_{}'.format(self.task_type))] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_push_pick_place_wall.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
@@ -52,11 +52,6 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -64,17 +59,17 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_reach_push_pick_and_place_wall.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -96,22 +91,8 @@ class SawyerReachPushPickPlaceWallEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal_{}'.format(self.task_type))] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerReachEnvV2(SawyerXYZEnv):
@@ -50,11 +50,6 @@ class SawyerReachEnvV2(SawyerXYZEnv):
         self.liftThresh = lift_thresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([+1, +1, +1, +1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -67,12 +62,12 @@ class SawyerReachEnvV2(SawyerXYZEnv):
         )
 
         self.num_resets = 0
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_reach_v2.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_v2.py
@@ -11,6 +11,8 @@ class SawyerReachEnvV2(SawyerXYZEnv):
         V1 was very difficult to solve because the observation didn't say where
         to move (where to reach).
     Changelog from V1 to V2:
+        - (7/7/20) Removed 3 element vector. Replaced with 3 element position
+            of the goal (for consistency with other environments)
         - (6/15/20) Added a 3 element vector to the observation. This vector
             points from the end effector to the goal coordinate.
             i.e. (self._state_goal - pos_hand)
@@ -59,10 +61,9 @@ class SawyerReachEnvV2(SawyerXYZEnv):
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_to_goal_max = self.hand_high - np.array(goal_low)
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, -hand_to_goal_max)),
-            np.hstack((self.hand_high, obj_high, hand_to_goal_max)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.num_resets = 0
@@ -94,20 +95,8 @@ class SawyerReachEnvV2(SawyerXYZEnv):
         self.curr_path_length += 1
         return ob, reward, False, info
 
-    def _get_obs(self):
-        pos_hand = self.get_endeff_pos()
-        pos_obj = self.data.get_geom_xpos('objGeom')
-        hand_to_goal = self._state_goal - pos_hand
-
-        flat_obs = np.concatenate((pos_hand, pos_obj, hand_to_goal))
-        return np.concatenate([flat_obs, ])
-
-    def _get_obs_dict(self):
-        return dict(
-            state_observation=self._get_obs(),
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = goal[:3]

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_reach_wall_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerReachWallEnvV2(SawyerXYZEnv):
@@ -51,11 +51,6 @@ class SawyerReachWallEnvV2(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -74,6 +69,7 @@ class SawyerReachWallEnvV2(SawyerXYZEnv):
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_reach_wall_v2.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerShelfPlaceEnv(SawyerXYZEnv):
@@ -37,11 +37,6 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -49,16 +44,15 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_shelf_placing.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -74,22 +68,8 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
@@ -48,11 +48,6 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -64,12 +59,11 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_shelf_placing.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_shelf_place_v2.py
@@ -12,6 +12,8 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
         where to move the block to (absolutely no information to reveal the
         goal state).
     Changelog from V1 to V2:
+        - (7/7/20) Removed 1 element vector. Replaced with 3 element position
+            of the goal (for consistency with other environments)
         - (6/24/20) Added a 1 element vector to the observation. This vector
             points along the x axis from the end effector to the goal's x
             coordinate. i.e. (self._state_goal[0] - pos_hand[:0])
@@ -57,11 +59,9 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
         )
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
-        hand_to_goal_max_x = self.hand_high[0] - np.array(goal_low)[0]
-
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, -hand_to_goal_max_x)),
-            np.hstack((self.hand_high, obj_high, hand_to_goal_max_x)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.reset()
@@ -85,20 +85,8 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        pos_hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        hand_to_goal_x = [self._state_goal[0] - pos_hand[0]]
-        flat_obs = np.concatenate((pos_hand, objPos, hand_to_goal_x))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        return dict(
-            state_observation=self._get_obs(),
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=self.data.get_geom_xpos('objGeom'),
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_soccer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_soccer.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerSoccerEnv(SawyerXYZEnv):
@@ -35,11 +35,6 @@ class SawyerSoccerEnv(SawyerXYZEnv):
 
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -47,16 +42,15 @@ class SawyerSoccerEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_soccer.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -72,22 +66,8 @@ class SawyerSoccerEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_stick_pull.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerStickPullEnv(SawyerXYZEnv):
@@ -36,11 +36,6 @@ class SawyerStickPullEnv(SawyerXYZEnv):
         self.liftThresh = liftThresh
         self.max_path_length = 200
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         # Fix object init position.
         self.obj_init_pos = np.array([0.2, 0.69, 0.04])
         self.obj_init_qpos = np.array([0., 0.09])
@@ -52,16 +47,15 @@ class SawyerStickPullEnv(SawyerXYZEnv):
         )
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low, obj_low)),
-            np.hstack((self.hand_high, obj_high, obj_high)),
+            np.hstack((self.hand_low, obj_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_stick_obj.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -77,25 +71,16 @@ class SawyerStickPullEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        stickPos = self.get_body_com('stick').copy()
-        objPos =  self.data.site_xpos[self.model.site_name2id('insertion')]
-        flat_obs = np.concatenate((hand, stickPos, objPos))
-
-        return np.concatenate([flat_obs,])
-
+    def _get_pos_objects(self):
+        return np.hstack((
+            self.get_body_com('stick').copy(),
+            self.data.site_xpos[self.model.site_name2id('insertion')],
+        ))
 
     def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        stickPos = self.get_body_com('stick').copy()
-        objPos =  self.data.site_xpos[self.model.site_name2id('insertion')]
-        flat_obs = np.concatenate((hand, stickPos, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+        obs_dict = super()._get_obs_dict()
+        obs_dict['state_achieved_goal'] = self.data.site_xpos[self.model.site_name2id('insertion')]
+        return obs_dict
 
     def _set_goal_marker(self, goal):
         """

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerSweepEnv(SawyerXYZEnv):
@@ -39,11 +39,6 @@ class SawyerSweepEnv(SawyerXYZEnv):
         self.max_path_length = 150
         self.init_puck_z = init_puck_z
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -51,16 +46,15 @@ class SawyerSweepEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_sweep.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -77,23 +71,8 @@ class SawyerSweepEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom').copy()
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom').copy()
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom').copy()
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_into_goal.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_sweep_into_goal.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
@@ -34,11 +34,6 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
         self.random_init = random_init
         self.max_path_length = 150
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.hstack((obj_low, goal_low)),
             np.hstack((obj_high, goal_high)),
@@ -46,16 +41,15 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_table_with_hole.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -71,22 +65,8 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.data.get_geom_xpos('objGeom')
-        flat_obs = np.concatenate((hand, objPos))
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.data.get_geom_xpos('objGeom')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import  Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerWindowCloseEnv(SawyerXYZEnv):
@@ -38,11 +38,6 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
         self.max_path_length = 150
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -50,16 +45,15 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_window_horizontal.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -75,23 +69,8 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleCloseStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleCloseStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.get_site_pos('handleCloseStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
@@ -11,6 +11,8 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
         V1 was rarely solvable due to limited path length. The window usually
         only got ~25% closed before hitting max_path_length
     Changelog from V1 to V2:
+        - (7/7/20) Added 3 element handle position to the observation
+            (for consistency with other environments)
         - (6/15/20) Increased max_path_length from 150 to 200
     """
     def __init__(self, random_init=False):
@@ -56,8 +58,8 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.reset()
@@ -81,23 +83,8 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleCloseStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleCloseStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.get_site_pos('handleCloseStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_close_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import  Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerWindowCloseEnvV2(SawyerXYZEnv):
@@ -46,11 +46,6 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
         self.max_path_length = 200
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -62,12 +57,11 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_window_horizontal.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import  Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerWindowOpenEnv(SawyerXYZEnv):
@@ -38,11 +38,6 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
         self.max_path_length = 150
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -50,16 +45,15 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
-
-        self.reset()
 
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_window_horizontal.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])
@@ -75,23 +69,8 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleOpenStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleOpenStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.get_site_pos('handleOpenStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
@@ -2,7 +2,7 @@ import numpy as np
 from gym.spaces import  Box
 
 from metaworld.envs.env_util import get_asset_full_path
-from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.base import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerWindowOpenEnvV2(SawyerXYZEnv):
@@ -45,11 +45,6 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
         self.max_path_length = 200
         self.liftThresh = liftThresh
 
-        self.action_space = Box(
-            np.array([-1, -1, -1, -1]),
-            np.array([1, 1, 1, 1]),
-        )
-
         self.obj_and_goal_space = Box(
             np.array(obj_low),
             np.array(obj_high),
@@ -61,12 +56,11 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
             np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
-        self.reset()
-
     @property
     def model_name(self):
         return get_asset_full_path('sawyer_xyz/sawyer_window_horizontal.xml')
 
+    @_assert_task_is_set
     def step(self, action):
         self.set_xyz_action(action[:3])
         self.do_simulation([action[-1], -action[-1]])

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_window_open_v2.py
@@ -10,6 +10,8 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
     Motivation for V2:
         When V1 scripted policy failed, it was often due to limited path length.
     Changelog from V1 to V2:
+        - (7/7/20) Added 3 element handle position to the observation
+            (for consistency with other environments)
         - (6/15/20) Increased max_path_length from 150 to 200
     """
     def __init__(self, random_init=False):
@@ -55,8 +57,8 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
         self.goal_space = Box(np.array(goal_low), np.array(goal_high))
 
         self.observation_space = Box(
-            np.hstack((self.hand_low, obj_low,)),
-            np.hstack((self.hand_high, obj_high,)),
+            np.hstack((self.hand_low, obj_low, goal_low)),
+            np.hstack((self.hand_high, obj_high, goal_high)),
         )
 
         self.reset()
@@ -80,23 +82,8 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
 
         return ob, reward, False, info
 
-    def _get_obs(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleOpenStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return np.concatenate([flat_obs,])
-
-    def _get_obs_dict(self):
-        hand = self.get_endeff_pos()
-        objPos =  self.get_site_pos('handleOpenStart')
-        flat_obs = np.concatenate((hand, objPos))
-
-        return dict(
-            state_observation=flat_obs,
-            state_desired_goal=self._state_goal,
-            state_achieved_goal=objPos,
-        )
+    def _get_pos_objects(self):
+        return self.get_site_pos('handleOpenStart')
 
     def _set_goal_marker(self, goal):
         self.data.site_xpos[self.model.site_name2id('goal')] = (

--- a/metaworld/policies/sawyer_button_press_topdown_v1_policy.py
+++ b/metaworld/policies/sawyer_button_press_topdown_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerButtonPressTopdownV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'button_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'button_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerButtonPressTopdownV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_button = o_d['button_xyz']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_button = o_d['button_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_button[:2]) > 0.04:
             return pos_button + np.array([0., 0., 0.1])

--- a/metaworld/policies/sawyer_button_press_v1_policy.py
+++ b/metaworld/policies/sawyer_button_press_v1_policy.py
@@ -9,8 +9,9 @@ class SawyerButtonPressV1Policy(Policy):
     @staticmethod
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'button_start_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'button_start_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -18,19 +19,18 @@ class SawyerButtonPressV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self.desired_xyz(o_d), p=4.)
-        action['grab_pow'] = 0.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self.desired_pos(o_d), p=4.)
+        action['grab_effort'] = 0.
 
         return action.array
 
     @staticmethod
-    def desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_button = o_d['button_start_xyz']
-        pos_button += np.array([0., 0., -0.07])
+    def desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_button = o_d['button_start_pos'] + np.array([0., 0., -0.07])
         
         # align the gripper with the button if the gripper does not have
         # the same x and z position as the button.

--- a/metaworld/policies/sawyer_coffee_button_v1_policy.py
+++ b/metaworld/policies/sawyer_coffee_button_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerCoffeeButtonV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'mug_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'mug_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerCoffeeButtonV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = -1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = -1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_mug = o_d['mug_xyz'] + np.array([.0, .0, .01])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_mug = o_d['mug_pos'] + np.array([.0, .0, .01])
 
         if abs(pos_curr[0] - pos_mug[0]) > 0.02:
             return np.array([pos_mug[0], pos_curr[1], .28])

--- a/metaworld/policies/sawyer_coffee_pull_v1_policy.py
+++ b/metaworld/policies/sawyer_coffee_pull_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerCoffeePullV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'mug_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'mug_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerCoffeePullV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_mug = o_d['mug_xyz']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_mug = o_d['mug_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_mug[:2]) > 0.06:
             return pos_mug + np.array([.0, .0, .15])
@@ -42,9 +43,9 @@ class SawyerCoffeePullV1Policy(Policy):
             return np.array([pos_curr[0] - .1, .62, .1])
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_mug = o_d['mug_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_mug = o_d['mug_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_mug[:2]) > 0.06 or \
             abs(pos_curr[2] - pos_mug[2]) > 0.06:

--- a/metaworld/policies/sawyer_coffee_push_v1_policy.py
+++ b/metaworld/policies/sawyer_coffee_push_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerCoffeePushV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'mug_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'mug_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerCoffeePushV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_mug = o_d['mug_xyz'] + np.array([.0, .0, .01])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_mug = o_d['mug_pos'] + np.array([.0, .0, .01])
 
         if np.linalg.norm(pos_curr[:2] - pos_mug[:2]) > 0.06:
             return pos_mug + np.array([.0, .0, .3])
@@ -42,9 +43,9 @@ class SawyerCoffeePushV1Policy(Policy):
             return np.array([-.1, .8, .1])
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_mug = o_d['mug_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_mug = o_d['mug_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_mug[:2]) > 0.06 or \
                 abs(pos_curr[2] - pos_mug[2]) > 0.15:

--- a/metaworld/policies/sawyer_door_close_v1_policy.py
+++ b/metaworld/policies/sawyer_door_close_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerDoorCloseV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'door_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'door_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerDoorCloseV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_door = o_d['door_xyz']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_door = o_d['door_pos']
         pos_door += np.array([0.13, 0.1, 0.02])
 
         # if to the right of door handle///

--- a/metaworld/policies/sawyer_door_open_v1_policy.py
+++ b/metaworld/policies/sawyer_door_open_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerDoorOpenV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'door_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'door_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerDoorOpenV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_door = o_d['door_xyz']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_door = o_d['door_pos']
         pos_door[0] -= 0.05
 
         # align end effector's Z axis with door handle's Z axis

--- a/metaworld/policies/sawyer_drawer_close_v1_policy.py
+++ b/metaworld/policies/sawyer_drawer_close_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerDrawerCloseV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'drwr_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'drwr_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerDrawerCloseV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_drwr = o_d['drwr_xyz']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_drwr = o_d['drwr_pos']
 
         # if further forward than the drawer...
         if pos_curr[1] > pos_drwr[1]:

--- a/metaworld/policies/sawyer_drawer_open_v1_policy.py
+++ b/metaworld/policies/sawyer_drawer_open_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerDrawerOpenV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'drwr_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'drwr_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,29 +20,29 @@ class SawyerDrawerOpenV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
         # NOTE this policy looks different from the others because it must
         # modify its p constant part-way through the task
-        pos_curr = o_d['hand_xyz']
-        pos_drwr = o_d['drwr_xyz']
+        pos_curr = o_d['hand_pos']
+        pos_drwr = o_d['drwr_pos']
 
         # align end effector's Z axis with drawer handle's Z axis
         if np.linalg.norm(pos_curr[:2] - pos_drwr[:2]) > 0.06:
-            to_xyz = pos_drwr + np.array([0., 0., 0.3])
-            action['delta_pos'] = move(o_d['hand_xyz'], to_xyz, p=4.)
+            to_pos = pos_drwr + np.array([0., 0., 0.3])
+            action['delta_pos'] = move(o_d['hand_pos'], to_pos, p=4.)
         # drop down to touch drawer handle
         elif abs(pos_curr[2] - pos_drwr[2]) > 0.04:
-            to_xyz = pos_drwr
-            action['delta_pos'] = move(o_d['hand_xyz'], to_xyz, p=4.)
+            to_pos = pos_drwr
+            action['delta_pos'] = move(o_d['hand_pos'], to_pos, p=4.)
         # push toward a point just behind the drawer handle
         # also increase p value to apply more force
         else:
-            to_xyz = pos_drwr + np.array([0., -0.06, 0.])
-            action['delta_pos'] = move(o_d['hand_xyz'], to_xyz, p=50.)
+            to_pos = pos_drwr + np.array([0., -0.06, 0.])
+            action['delta_pos'] = move(o_d['hand_pos'], to_pos, p=50.)
 
         # keep gripper open
-        action['grab_pow'] = -1.
+        action['grab_effort'] = -1.
 
         return action.array

--- a/metaworld/policies/sawyer_lever_pull_v2_policy.py
+++ b/metaworld/policies/sawyer_lever_pull_v2_policy.py
@@ -10,8 +10,9 @@ class SawyerLeverPullV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'lever_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'lever_pos': obs[3:6],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerLeverPullV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_lever = o_d['lever_xyz'] + np.array([.0, -.04, .0])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_lever = o_d['lever_pos'] + np.array([.0, -.04, .0])
 
         if np.linalg.norm(pos_curr[:2] - pos_lever[:2]) > 0.04:
             return pos_lever + np.array([0., 0., 0.3])

--- a/metaworld/policies/sawyer_pick_place_v2_policy.py
+++ b/metaworld/policies/sawyer_pick_place_v2_policy.py
@@ -10,9 +10,9 @@ class SawyerPickPlaceV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:-3],
-            'goal_vec': obs[-3:]
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:6],
+            'goal_pos': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -20,19 +20,19 @@ class SawyerPickPlaceV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz']
-        goal_vec = o_d['goal_vec']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos']
+        pos_goal = o_d['goal_pos']
 
         # If error in the XY plane is greater than 0.02, place end effector above the puck
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.02:
@@ -41,16 +41,16 @@ class SawyerPickPlaceV2Policy(Policy):
         elif abs(pos_curr[2] - pos_puck[2]) > 0.05 and pos_puck[-1] < 0.03:
             return pos_puck + np.array([0., 0., 0.03])
         # If not at the same Z height as the goal, move up to that plane
-        elif abs(goal_vec[-1]) > 0.04:
-            return pos_curr + np.array([0., 0., goal_vec[-1]])
+        elif abs(pos_curr[2] - pos_goal[2]) > 0.04:
+            return np.array([pos_curr[0], pos_curr[1], pos_goal[2]])
         # Move to the goal
         else:
-            return pos_curr + goal_vec
+            return pos_goal
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.02 or abs(pos_curr[2] - pos_puck[2]) > 0.1:
             return 0.

--- a/metaworld/policies/sawyer_plate_slide_back_side_v2_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_back_side_v2_policy.py
@@ -10,8 +10,9 @@ class SawyerPlateSlideBackSideV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:6],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerPlateSlideBackSideV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_xyz(o_d), p=10.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
     def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz'] + np.array([.023, .0, .025])
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos'] + np.array([.023, .0, .025])
 
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.01:
             return pos_puck + np.array([.0, .0, .07])

--- a/metaworld/policies/sawyer_plate_slide_back_v1_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_back_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerPlateSlideBackV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerPlateSlideBackV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = -1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = -1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz'] + np.array([.0, -.065, .025])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos'] + np.array([.0, -.065, .025])
 
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.01:
             return pos_puck + np.array([.0, .0, .1])

--- a/metaworld/policies/sawyer_plate_slide_side_v1_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_side_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerPlateSlideSideV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerPlateSlideSideV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz'] + np.array([.07, .0, -.005])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos'] + np.array([.07, .0, -.005])
 
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.04:
             return pos_puck + np.array([.0, .0, .1])

--- a/metaworld/policies/sawyer_plate_slide_v2_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_v2_policy.py
@@ -10,9 +10,10 @@ class SawyerPlateSlideV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:-1],
-            'shelf_vec': obs[-1],
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:6],
+            'shelf_x': obs[-3],
+            'extra_info': obs[-2:],
         }
 
     def get_action(self, obs):
@@ -20,18 +21,18 @@ class SawyerPlateSlideV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = -1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = -1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz'] + np.array([.0, -.055, .03])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos'] + np.array([.0, -.055, .03])
 
         aligned_with_puck = np.linalg.norm(pos_curr[:2] - pos_puck[:2]) <= 0.03
 
@@ -40,4 +41,4 @@ class SawyerPlateSlideV2Policy(Policy):
         elif abs(pos_curr[2] - pos_puck[2]) > 0.04:
             return pos_puck
         else:
-            return np.array([pos_curr[0] + o_d['shelf_vec'], .9, pos_puck[2]])
+            return np.array([o_d['shelf_x'], .9, pos_puck[2]])

--- a/metaworld/policies/sawyer_push_v2_policy.py
+++ b/metaworld/policies/sawyer_push_v2_policy.py
@@ -10,9 +10,9 @@ class SawyerPushV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:-3],
-            'goal_vec': obs[-3:]
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:6],
+            'goal_pos': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -20,18 +20,18 @@ class SawyerPushV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=10.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=10.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos']
 
         # If error in the XY plane is greater than 0.02, place end effector above the puck
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.02:
@@ -41,12 +41,12 @@ class SawyerPushV2Policy(Policy):
             return pos_puck + np.array([0., 0., 0.03])
         # Move to the goal
         else:
-            return pos_curr + o_d['goal_vec']
+            return o_d['goal_pos']
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_puck = o_d['puck_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_puck = o_d['puck_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_puck[:2]) > 0.02 or abs(pos_curr[2] - pos_puck[2]) > 0.1:
             return 0.

--- a/metaworld/policies/sawyer_reach_v2_policy.py
+++ b/metaworld/policies/sawyer_reach_v2_policy.py
@@ -10,9 +10,9 @@ class SawyerReachV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'puck_xyz': obs[3:-3],
-            'goal_vec': obs[-3:]
+            'hand_pos': obs[:3],
+            'puck_pos': obs[3:-3],
+            'goal_pos': obs[-3:]
         }
 
     def get_action(self, obs):
@@ -20,14 +20,10 @@ class SawyerReachV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=5.)
-        action['grab_pow'] = 0.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=o_d['goal_pos'], p=5.)
+        action['grab_effort'] = 0.
 
         return action.array
-
-    @staticmethod
-    def _desired_xyz(o_d):
-        return o_d['hand_xyz'] + o_d['goal_vec']

--- a/metaworld/policies/sawyer_shelf_place_v2_policy.py
+++ b/metaworld/policies/sawyer_shelf_place_v2_policy.py
@@ -10,9 +10,10 @@ class SawyerShelfPlaceV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'block_xyz': obs[3:-1],
-            'x_vec': obs[-1:]
+            'hand_pos': obs[:3],
+            'block_pos': obs[3:6],
+            'shelf_x': obs[-3],
+            'extra_info': obs[-2:],
         }
 
     def get_action(self, obs):
@@ -20,29 +21,28 @@ class SawyerShelfPlaceV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_block = o_d['block_xyz'] + np.array([.005, .0, .015])
-        x_vec = o_d['x_vec']
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_block = o_d['block_pos'] + np.array([.005, .0, .015])
+        pos_shelf_x = o_d['shelf_x']
         if np.linalg.norm(pos_curr[:2] - pos_block[:2]) > 0.04:
             # positioning over block
             return pos_block + np.array([0., 0., 0.3])
         elif abs(pos_curr[2] - pos_block[2]) > 0.02:
             # grabbing block 
             return pos_block
-        elif np.abs(x_vec) > 0.02:
+        elif np.abs(pos_curr[0] - pos_shelf_x) > 0.02:
             # centering with goal pos
-            pos_new = pos_curr + np.array([x_vec, 0., 0.])
-            return pos_new
+            return np.array([pos_shelf_x, pos_curr[1], pos_curr[2]])
         elif pos_curr[2] < 0.25:
             # move up to correct height
             pos_new = pos_curr + np.array([0., 0., 0.25])
@@ -53,9 +53,9 @@ class SawyerShelfPlaceV2Policy(Policy):
             return pos_new
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_block = o_d['block_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_block = o_d['block_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_block[:2]) > 0.04 \
             or abs(pos_curr[2] - pos_block[2]) > 0.15:

--- a/metaworld/policies/sawyer_sweep_into_v1_policy.py
+++ b/metaworld/policies/sawyer_sweep_into_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerSweepIntoV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'cube_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'cube_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerSweepIntoV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_cube = o_d['cube_xyz'] + np.array([.0, .0, .015])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_cube = o_d['cube_pos'] + np.array([.0, .0, .015])
 
         if np.linalg.norm(pos_curr[:2] - pos_cube[:2]) > 0.04:
             return pos_cube + np.array([0., 0., 0.3])
@@ -40,9 +41,9 @@ class SawyerSweepIntoV1Policy(Policy):
             return np.array([.0, .8, .015])
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_cube = o_d['cube_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_cube = o_d['cube_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_cube[:2]) > 0.04 \
             or abs(pos_curr[2] - pos_cube[2]) > 0.15:

--- a/metaworld/policies/sawyer_sweep_v1_policy.py
+++ b/metaworld/policies/sawyer_sweep_v1_policy.py
@@ -10,8 +10,9 @@ class SawyerSweepV1Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'cube_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'cube_pos': obs[3:-3],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,18 +20,18 @@ class SawyerSweepV1Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = self._grab_pow(o_d)
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = self._grab_effort(o_d)
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_cube = o_d['cube_xyz'] + np.array([.0, .0, .015])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_cube = o_d['cube_pos'] + np.array([.0, .0, .015])
 
         if pos_curr[0] < .2:
             if np.linalg.norm(pos_curr[:2] - pos_cube[:2]) > 0.04:
@@ -41,9 +42,9 @@ class SawyerSweepV1Policy(Policy):
         return np.array([.5, pos_cube[1], .1])
 
     @staticmethod
-    def _grab_pow(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_cube = o_d['cube_xyz']
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_cube = o_d['cube_pos']
 
         if np.linalg.norm(pos_curr[:2] - pos_cube[:2]) > 0.04 \
             or abs(pos_curr[2] - pos_cube[2]) > 0.15:

--- a/metaworld/policies/sawyer_window_close_v2_policy.py
+++ b/metaworld/policies/sawyer_window_close_v2_policy.py
@@ -10,8 +10,9 @@ class SawyerWindowCloseV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'wndw_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'wndw_pos': obs[3:6],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,19 +20,18 @@ class SawyerWindowCloseV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_wndw = o_d['wndw_xyz']
-        pos_wndw += np.array([+0.03, -0.03, -0.1])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_wndw = o_d['wndw_pos'] + np.array([+0.03, -0.03, -0.1])
 
         if np.linalg.norm(pos_curr[:2] - pos_wndw[:2]) > 0.04:
             return pos_wndw + np.array([0., 0., 0.3])

--- a/metaworld/policies/sawyer_window_open_v2_policy.py
+++ b/metaworld/policies/sawyer_window_open_v2_policy.py
@@ -10,8 +10,9 @@ class SawyerWindowOpenV2Policy(Policy):
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
-            'hand_xyz': obs[:3],
-            'wndw_xyz': obs[3:],
+            'hand_pos': obs[:3],
+            'wndw_pos': obs[3:6],
+            'extra_info': obs[-3:],
         }
 
     def get_action(self, obs):
@@ -19,19 +20,18 @@ class SawyerWindowOpenV2Policy(Policy):
 
         action = Action({
             'delta_pos': np.arange(3),
-            'grab_pow': 3
+            'grab_effort': 3
         })
 
-        action['delta_pos'] = move(o_d['hand_xyz'], to_xyz=self._desired_xyz(o_d), p=25.)
-        action['grab_pow'] = 1.
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
+        action['grab_effort'] = 1.
 
         return action.array
 
     @staticmethod
-    def _desired_xyz(o_d):
-        pos_curr = o_d['hand_xyz']
-        pos_wndw = o_d['wndw_xyz']
-        pos_wndw += np.array([-0.03, -0.03, -0.1])
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_wndw = o_d['wndw_pos'] + np.array([-0.03, -0.03, -0.1])
 
         if np.linalg.norm(pos_curr[:2] - pos_wndw[:2]) > 0.04:
             return pos_wndw + np.array([0., 0., 0.3])

--- a/tests/metaworld/benchmarks/test_mt10.py
+++ b/tests/metaworld/benchmarks/test_mt10.py
@@ -10,6 +10,10 @@ def test_augment_observation():
     env = MT10()
     for i in range(env.num_tasks):
         env.set_task(i)
+        # Right now, env.reset() calls env.active_env.set_task() under the hood
+        # This is necessary before stepping, and calling the method directly
+        # right here doesn't seem to work.
+        env.reset()
         obs, _, _, _ = env.step(env.action_space.sample())
         assert obs[-10:][i] == 1
         obs = env.reset()

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_sawyer_parameterized.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_sawyer_parameterized.py
@@ -21,14 +21,16 @@ def env(request):
     env.close()
 
 def test_all_envs_step(env):
+    env.set_task(is_partially_observable=False)
     step_env(env, max_path_length=10)
 
 def test_obs_type(env):
+    env.set_task(is_partially_observable=False)
     o = env.reset()
     o_g = env._get_obs()
     space = env.observation_space
-    assert space.shape == o.shape, 'type: {}, env: {}'.format(t, env)
-    assert space.shape == o_g.shape, 'type: {}, env: {}'.format(t, env)
+    assert space.shape == o.shape, 'env: {}'.format(env)
+    assert space.shape == o_g.shape, 'env: {}'.format(env)
 
 def test_discretize_goal_space(env):
     discrete_goals = env.sample_goals_(2)
@@ -47,6 +49,7 @@ def test_discretize_goal_space(env):
 # I leave two environment's refactoring at the end since they
 # contain more than one task.
 def test_init_config(env):
+    env.set_task(is_partially_observable=False)
     env.reset()
     assert 'init_config' in dir(env)
     assert np.all(env.goal_space.shape == env.goal.shape), 'goal: {}, goal_high: {}, goal_low: {}'.format(env.goal, env.goal_space.high, env.goal_space.low)

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
@@ -48,7 +48,7 @@ test_cases_latest_nonoise = [
     ['sweep-into-v1', SawyerSweepIntoV1Policy(), .0, 1.],
     ['sweep-v1', SawyerSweepV1Policy(), .0, 1.],
     ['window-close-v2', SawyerWindowCloseV2Policy(), 0., 0.98],
-    ['window-open-v2', SawyerWindowOpenV2Policy(), 0., 0.96],
+    ['window-open-v2', SawyerWindowOpenV2Policy(), 0., 0.95],
 ]
 
 test_cases_latest_noisy = [
@@ -98,7 +98,9 @@ ALL_ENVS = {**ALL_V1_ENVIRONMENTS, **ALL_V2_ENVIRONMENTS}
 
 @pytest.fixture(scope='function')
 def env(request):
-    return ALL_ENVS[request.param](random_init=True)
+    e = ALL_ENVS[request.param](random_init=True)
+    e.set_task(False)
+    return e
 
 
 @pytest.mark.parametrize(

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
@@ -5,67 +5,6 @@ from metaworld.policies import *
 from tests.metaworld.envs.mujoco.sawyer_xyz.utils import check_success
 
 
-test_cases = [
-    # name, policy, action noise pct, success rate, env kwargs
-    ['button-press-topdown-v1', SawyerButtonPressTopdownV1Policy(), .0, 1., {}],
-    ['button-press-topdown-v1', SawyerButtonPressTopdownV1Policy(), .1, .99, {}],
-    ['door-open-v1', SawyerDoorOpenV1Policy(), .0, 0.99, {}],
-    ['door-open-v1', SawyerDoorOpenV1Policy(), .1, 0.97, {}],
-    ['door-close-v1', SawyerDoorCloseV1Policy(), .0, 0.99, {}],
-    ['door-close-v1', SawyerDoorCloseV1Policy(), .1, 0.99, {}],
-    ['drawer-open-v1', SawyerDrawerOpenV1Policy(), .0, 0.99, {}],
-    ['drawer-open-v1', SawyerDrawerOpenV1Policy(), .1, 0.98, {}],
-    ['drawer-close-v1', SawyerDrawerCloseV1Policy(), .0, 0.99, {}],
-    ['drawer-close-v1', SawyerDrawerCloseV1Policy(), .1, 0.75, {}],
-    ['lever-pull-v2', SawyerLeverPullV2Policy(), .0, 1., {}],
-    ['lever-pull-v2', SawyerLeverPullV2Policy(), .1, 1., {}],
-    ['plate-slide-back-side-v1', SawyerPlateSlideBackSideV2Policy(), .0, 1., {}],
-    ['plate-slide-back-side-v1', SawyerPlateSlideBackSideV2Policy(), .1, 0.30, {}],
-    ['plate-slide-back-side-v2', SawyerPlateSlideBackSideV2Policy(), .0, 1., {}],
-    ['plate-slide-back-side-v2', SawyerPlateSlideBackSideV2Policy(), .1, 0.97, {}],
-    ['plate-slide-back-v1', SawyerPlateSlideBackV1Policy(), .0, 1., {}],
-    ['plate-slide-back-v1', SawyerPlateSlideBackV1Policy(), .1, .96, {}],
-    ['plate-slide-side-v1', SawyerPlateSlideSideV1Policy(), .0, 1., {}],
-    ['plate-slide-side-v1', SawyerPlateSlideSideV1Policy(), .1, .80, {}],
-    ['plate-slide-v2', SawyerPlateSlideV2Policy(), .0, 1., {}],
-    ['plate-slide-v2', SawyerPlateSlideV2Policy(), .1, .99, {}],
-    ['reach-v2', SawyerReachV2Policy(), .0, .99, {}],
-    ['reach-v2', SawyerReachV2Policy(), .1, .99, {}],
-    ['push-v2', SawyerPushV2Policy(), .0, .99, {}],
-    ['push-v2', SawyerPushV2Policy(), .1, .97, {}],
-    ['pick-place-v2', SawyerPickPlaceV2Policy(), .0, .96, {}],
-    ['pick-place-v2', SawyerPickPlaceV2Policy(), .1, .92, {}],
-    ['basketball-v2', SawyerBasketballV2Policy(), .0, .99, {}],
-    ['basketball-v2', SawyerBasketballV2Policy(), .1, .99, {}],
-    ['peg-insert-side-v2', SawyerPegInsertionSideV2Policy(), .0, .94, {}],
-    ['peg-insert-side-v2', SawyerPegInsertionSideV2Policy(), .1, .92, {}],
-    ['peg-unplug-side-v1', SawyerPegUnplugSideV1Policy(), .0, .99, {}],
-    ['peg-unplug-side-v1', SawyerPegUnplugSideV1Policy(), .1, .98, {}],
-    ['sweep-into-v1', SawyerSweepIntoV1Policy(), .0, 1., {}],
-    ['sweep-into-v1', SawyerSweepIntoV1Policy(), .1, 1., {}],
-    ['sweep-v1', SawyerSweepV1Policy(), .0, 1., {}],
-    ['sweep-v1', SawyerSweepV1Policy(), .1, 1., {}],
-    # drop the success rate threshold of this env by 0.05 due to its flakiness
-    ['window-open-v1', SawyerWindowOpenV2Policy(), .0, 0.80, {}],
-    ['window-open-v1', SawyerWindowOpenV2Policy(), .1, 0.81, {}],
-    ['window-open-v2', SawyerWindowOpenV2Policy(), 0., 0.96, {}],
-    ['window-open-v2', SawyerWindowOpenV2Policy(), .1, 0.96, {}],
-    ['window-close-v1', SawyerWindowCloseV2Policy(), .0, 0.37, {}],
-    ['window-close-v1', SawyerWindowCloseV2Policy(), .1, 0.37, {}],
-    # drop the success rate threshold of this env by 0.05 due to its flakiness
-    ['window-close-v2', SawyerWindowCloseV2Policy(), 0., 0.93, {}],
-    # drop the success rate threshold of this env by 0.05 due to its flakiness
-    ['window-close-v2', SawyerWindowCloseV2Policy(), .1, 0.92, {}],
-    ['button-press-v1', SawyerButtonPressV1Policy(), 0., 0.94, {}],
-    ['shelf-place-v2', SawyerShelfPlaceV2Policy(), 0.1, 0.93, {}],
-    ['reach-wall-v2', SawyerReachWallV2Policy(), 0.0, 0.98, {}],
-    ['reach-wall-v2', SawyerReachWallV2Policy(), 0.1, 0.98, {}],
-    ['pick-place-wall-v2', SawyerPickPlaceWallV2Policy(), 0.0, 0.95, {}],
-    ['pick-place-wall-v2', SawyerPickPlaceWallV2Policy(), 0.1, 0.92, {}],
-    ['push-wall-v2', SawyerPushWallV2Policy(), 0.0, 0.95, {}],
-    ['push-wall-v2', SawyerPushWallV2Policy(), 0.1, 0.85, {}],
-]
-
 test_cases_old_nonoise = [
     # This should contain configs where a V2 policy is compatible with a V1 env.
     # name, policy, action noise pct, success rate

--- a/tests/metaworld/envs/test_multitask_env.py
+++ b/tests/metaworld/envs/test_multitask_env.py
@@ -195,6 +195,10 @@ def test_task_name():
     env = ML10.get_test_tasks()
     assert sorted(env.all_task_names) == sorted(task_names)
 
+    # Right now, env.reset() calls env.active_env.set_task() under the hood
+    # This is necessary before stepping, and calling the method directly
+    # right here doesn't seem to work.
+    env.reset()
     _, _, _, info = env.step(env.action_space.sample())
     assert info['task_name'] in task_names
 
@@ -210,9 +214,9 @@ def test_observation_space(observation_type):
         obs_type=observation_type,
     )
     if observation_type == 'plain':
-        assert multi_task_env.observation_space.shape == (9, )
+        assert multi_task_env.observation_space.shape == (12, )
     elif observation_type == 'with_goal_id':
-        assert multi_task_env.observation_space.shape == (59, )
+        assert multi_task_env.observation_space.shape == (62, )
 
 
 def test_action_space():


### PR DESCRIPTION
In v1, every observation included the end effector's position and object positions. In v2, we want every observation to include those things, as well as the goal position. The goal position is always given by `self._state_goal`, so I was able to refactor much of the observation out of the individual environments and into the `SawyerXYZEnv` base class.

Now, environments only need to implement the `_get_pos_objects` function, and the base class' `_get_obs` does the rest. The presence of the goal in the observation is controlled by an instance property, `_include_goal_in_obs`, which is `True` by default. This means that some v1 and v2 environments are now practically identical (reach, for example). 

In light of these changes, I also had to modify the scripted policies. In some cases, having the additional information about the goal's position could lead to higher success rates, but for now I maintained the convention of using as little information as possible. Information that wasn't there before this commit is given the `'extra_info'` key in the `_parse_obs` function.

I also fixed #118 and #124 in the policies that I touched.