### PR TITLE
Scripted policies for button wall envs

### DIFF
--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -1,63 +1,65 @@
 from collections import OrderedDict
 
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_v2 import SawyerReachEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_v2 import SawyerPushEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_place_v2 import SawyerPickPlaceEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_hand_insert import SawyerHandInsertEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press_side_v2 import SawyerHandlePressSideEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_assembly_peg import SawyerNutAssemblyEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_sweep import SawyerSweepEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open import SawyerWindowOpenEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open_v2 import SawyerWindowOpenEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_hammer import SawyerHammerEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close import SawyerWindowCloseEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close_v2 import SawyerWindowCloseEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_dial_turn import SawyerDialTurnEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_lever_pull import SawyerLeverPullEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_lever_pull_v2 import SawyerLeverPullEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_open import SawyerDrawerOpenEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_topdown import SawyerButtonPressTopdownEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_close import SawyerDrawerCloseEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_box_close import SawyerBoxCloseEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_insertion_side import SawyerPegInsertionSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_insertion_side_v2 import SawyerPegInsertionSideEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_bin_picking import SawyerBinPickingEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_push import SawyerStickPushEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_pull import SawyerStickPullEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press import SawyerButtonPressEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_shelf_place import SawyerShelfPlaceEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_close import SawyerDoorCloseEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_sweep_into_goal import SawyerSweepIntoGoalEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_button import SawyerCoffeeButtonEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_push import SawyerCoffeePushEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_pull import SawyerCoffeePullEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_faucet_open import SawyerFaucetOpenEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_faucet_close import SawyerFaucetCloseEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_unplug_side import SawyerPegUnplugSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_soccer import SawyerSoccerEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_basketball import SawyerBasketballEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place import SawyerReachPushPickPlaceEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place_wall import SawyerReachPushPickPlaceWallEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_wall_v2 import SawyerReachWallEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_wall_v2 import SawyerPushWallEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_place_wall_v2 import SawyerPickPlaceWallEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_back import SawyerPushBackEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_out_of_hole import SawyerPickOutOfHoleEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_disassemble_peg import SawyerNutDisassembleEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_lock import SawyerDoorLockEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_unlock import SawyerDoorUnlockEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_wall import SawyerButtonPressWallEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_topdown_wall import SawyerButtonPressTopdownWallEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press import SawyerHandlePressEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_pull import SawyerHandlePullEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press_side import SawyerHandlePressSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_pull_side import SawyerHandlePullSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide import SawyerPlateSlideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back import SawyerPlateSlideBackEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_side import SawyerPlateSlideSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side import SawyerPlateSlideBackSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side_v2 import SawyerPlateSlideBackSideEnvV2
+from metaworld.envs.mujoco.sawyer_xyz import (
+    SawyerNutAssemblyEnv,
+    SawyerBasketballEnv,
+    SawyerBinPickingEnv,
+    SawyerBoxCloseEnv,
+    SawyerButtonPressEnv,
+    SawyerButtonPressTopdownEnv,
+    SawyerButtonPressTopdownWallEnv,
+    SawyerButtonPressWallEnv,
+    SawyerCoffeeButtonEnv,
+    SawyerCoffeePullEnv,
+    SawyerCoffeePushEnv,
+    SawyerDialTurnEnv,
+    SawyerNutDisassembleEnv,
+    SawyerDoorEnv,
+    SawyerDoorCloseEnv,
+    SawyerDoorLockEnv,
+    SawyerDoorUnlockEnv,
+    SawyerDrawerCloseEnv,
+    SawyerDrawerOpenEnv,
+    SawyerFaucetCloseEnv,
+    SawyerFaucetOpenEnv,
+    SawyerHammerEnv,
+    SawyerHandInsertEnv,
+    SawyerHandlePressEnv,
+    SawyerHandlePressSideEnv,
+    SawyerHandlePressSideEnvV2,
+    SawyerHandlePullEnv,
+    SawyerHandlePullSideEnv,
+    SawyerLeverPullEnv,
+    SawyerLeverPullEnvV2,
+    SawyerPegInsertionSideEnv,
+    SawyerPegInsertionSideEnvV2,
+    SawyerPegUnplugSideEnv,
+    SawyerPickOutOfHoleEnv,
+    SawyerPickPlaceEnvV2,
+    SawyerPickPlaceWallEnvV2,
+    SawyerPlateSlideEnv,
+    SawyerPlateSlideBackEnv,
+    SawyerPlateSlideBackSideEnv,
+    SawyerPlateSlideBackSideEnvV2,
+    SawyerPlateSlideSideEnv,
+    SawyerPushBackEnv,
+    SawyerPushEnvV2,
+    SawyerPushWallEnvV2,
+    SawyerReachPushPickPlaceEnv,
+    SawyerReachPushPickPlaceWallEnv,
+    SawyerReachEnvV2,
+    SawyerReachWallEnvV2,
+    SawyerShelfPlaceEnv,
+    SawyerSoccerEnv,
+    SawyerStickPullEnv,
+    SawyerStickPushEnv,
+    SawyerSweepEnv,
+    SawyerSweepIntoGoalEnv,
+    SawyerWindowCloseEnv,
+    SawyerWindowCloseEnvV2,
+    SawyerWindowOpenEnv,
+    SawyerWindowOpenEnvV2,
+)
 
 ALL_V1_ENVIRONMENTS = OrderedDict((
     ('reach-v1', SawyerReachPushPickPlaceEnv),

--- a/metaworld/envs/mujoco/sawyer_xyz/__init__.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/__init__.py
@@ -1,25 +1,53 @@
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_assembly_peg import SawyerNutAssemblyEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_basketball import SawyerBasketballEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_bin_picking import SawyerBinPickingEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_box_close import SawyerBoxCloseEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press import SawyerButtonPressEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_topdown import SawyerButtonPressTopdownEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_topdown_wall import SawyerButtonPressTopdownWallEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_wall import SawyerButtonPressWallEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_button import SawyerCoffeeButtonEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_pull import SawyerCoffeePullEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_push import SawyerCoffeePushEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_dial_turn import SawyerDialTurnEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_disassemble_peg import SawyerNutDisassembleEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_door import SawyerDoorEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_close import SawyerDoorCloseEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_lock import SawyerDoorLockEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_unlock import SawyerDoorUnlockEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_close import SawyerDrawerCloseEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_drawer_open import SawyerDrawerOpenEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_faucet_close import SawyerFaucetCloseEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_faucet_open import SawyerFaucetOpenEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_hammer import SawyerHammerEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_hand_insert import SawyerHandInsertEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press import SawyerHandlePressEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press_side import SawyerHandlePressSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press_side_v2 import SawyerHandlePressSideEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_pull import SawyerHandlePullEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_pull_side import SawyerHandlePullSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_lever_pull import SawyerLeverPullEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_lever_pull_v2 import SawyerLeverPullEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_insertion_side import SawyerPegInsertionSideEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_insertion_side_v2 import SawyerPegInsertionSideEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_unplug_side import SawyerPegUnplugSideEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_out_of_hole import SawyerPickOutOfHoleEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_place_v2 import SawyerPickPlaceEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_place_wall_v2 import SawyerPickPlaceWallEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide import SawyerPlateSlideEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back import SawyerPlateSlideBackEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side import SawyerPlateSlideBackSideEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side_v2 import SawyerPlateSlideBackSideEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_side import SawyerPlateSlideSideEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_back import SawyerPushBackEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_v2 import SawyerPushEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_v2 import SawyerReachEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_wall_v2 import SawyerPushWallEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place import SawyerReachPushPickPlaceEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place_wall import SawyerReachPushPickPlaceWallEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_v2 import SawyerReachEnvV2
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_wall_v2 import SawyerReachWallEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_shelf_place import SawyerShelfPlaceEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_soccer import SawyerSoccerEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_pull import SawyerStickPullEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_stick_push import SawyerStickPushEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_sweep import SawyerSweepEnv
@@ -28,26 +56,65 @@ from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close import SawyerWindowClo
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_close_v2 import SawyerWindowCloseEnvV2
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open import SawyerWindowOpenEnv
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_window_open_v2 import SawyerWindowOpenEnvV2
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_button import SawyerCoffeeButtonEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_push import SawyerCoffeePushEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_coffee_pull import SawyerCoffeePullEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_faucet_open import SawyerFaucetOpenEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_faucet_close import SawyerFaucetCloseEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_peg_unplug_side import SawyerPegUnplugSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_soccer import SawyerSoccerEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_basketball import SawyerBasketballEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_reach_push_pick_place_wall import SawyerReachPushPickPlaceWallEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_push_back import SawyerPushBackEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_pick_out_of_hole import SawyerPickOutOfHoleEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_disassemble_peg import SawyerNutDisassembleEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_lock import SawyerDoorLockEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_door_unlock import SawyerDoorUnlockEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_wall import SawyerButtonPressWallEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_button_press_topdown_wall import SawyerButtonPressTopdownWallEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_press_side import SawyerHandlePressSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_handle_pull_side import SawyerHandlePullSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide import SawyerPlateSlideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back import SawyerPlateSlideBackEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_side import SawyerPlateSlideSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side import SawyerPlateSlideBackSideEnv
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_plate_slide_back_side_v2 import SawyerPlateSlideBackSideEnvV2
+
+
+__all__ = [
+    'SawyerNutAssemblyEnv',
+    'SawyerBasketballEnv',
+    'SawyerBinPickingEnv',
+    'SawyerBoxCloseEnv',
+    'SawyerButtonPressEnv',
+    'SawyerButtonPressTopdownEnv',
+    'SawyerButtonPressTopdownWallEnv',
+    'SawyerButtonPressWallEnv',
+    'SawyerCoffeeButtonEnv',
+    'SawyerCoffeePullEnv',
+    'SawyerCoffeePushEnv',
+    'SawyerDialTurnEnv',
+    'SawyerNutDisassembleEnv',
+    'SawyerDoorEnv',
+    'SawyerDoorCloseEnv',
+    'SawyerDoorLockEnv',
+    'SawyerDoorUnlockEnv',
+    'SawyerDrawerCloseEnv',
+    'SawyerDrawerOpenEnv',
+    'SawyerFaucetCloseEnv',
+    'SawyerFaucetOpenEnv',
+    'SawyerHammerEnv',
+    'SawyerHandInsertEnv',
+    'SawyerHandlePressEnv',
+    'SawyerHandlePressSideEnv',
+    'SawyerHandlePressSideEnvV2',
+    'SawyerHandlePullEnv',
+    'SawyerHandlePullSideEnv',
+    'SawyerLeverPullEnv',
+    'SawyerLeverPullEnvV2',
+    'SawyerPegInsertionSideEnv',
+    'SawyerPegInsertionSideEnvV2',
+    'SawyerPegUnplugSideEnv',
+    'SawyerPickOutOfHoleEnv',
+    'SawyerPickPlaceEnvV2',
+    'SawyerPickPlaceWallEnvV2',
+    'SawyerPlateSlideEnv',
+    'SawyerPlateSlideBackEnv',
+    'SawyerPlateSlideBackSideEnv',
+    'SawyerPlateSlideBackSideEnvV2',
+    'SawyerPlateSlideSideEnv',
+    'SawyerPushBackEnv',
+    'SawyerPushEnvV2',
+    'SawyerPushWallEnvV2',
+    'SawyerReachPushPickPlaceEnv',
+    'SawyerReachPushPickPlaceWallEnv',
+    'SawyerReachEnvV2',
+    'SawyerReachWallEnvV2',
+    'SawyerShelfPlaceEnv',
+    'SawyerSoccerEnv',
+    'SawyerStickPullEnv',
+    'SawyerStickPushEnv',
+    'SawyerSweepEnv',
+    'SawyerSweepIntoGoalEnv',
+    'SawyerWindowCloseEnv',
+    'SawyerWindowCloseEnvV2',
+    'SawyerWindowOpenEnv',
+    'SawyerWindowOpenEnvV2',
+]

--- a/metaworld/policies/__init__.py
+++ b/metaworld/policies/__init__.py
@@ -2,7 +2,9 @@ from metaworld.policies.sawyer_assembly_v1_policy import SawyerAssemblyV1Policy
 from metaworld.policies.sawyer_basketball_v1_policy import SawyerBasketballV1Policy
 from metaworld.policies.sawyer_box_close_v1_policy import SawyerBoxCloseV1Policy
 from metaworld.policies.sawyer_button_press_topdown_v1_policy import SawyerButtonPressTopdownV1Policy
+from metaworld.policies.sawyer_button_press_topdown_wall_v1_policy import SawyerButtonPressTopdownWallV1Policy
 from metaworld.policies.sawyer_button_press_v1_policy import SawyerButtonPressV1Policy
+from metaworld.policies.sawyer_button_press_wall_v1_policy import SawyerButtonPressWallV1Policy
 from metaworld.policies.sawyer_coffee_button_v1_policy import SawyerCoffeeButtonV1Policy
 from metaworld.policies.sawyer_coffee_pull_v1_policy import SawyerCoffeePullV1Policy
 from metaworld.policies.sawyer_coffee_push_v1_policy import SawyerCoffeePushV1Policy
@@ -43,12 +45,15 @@ from metaworld.policies.sawyer_sweep_v1_policy import SawyerSweepV1Policy
 from metaworld.policies.sawyer_window_close_v2_policy import SawyerWindowCloseV2Policy
 from metaworld.policies.sawyer_window_open_v2_policy import SawyerWindowOpenV2Policy
 
+
 __all__ = [
     'SawyerAssemblyV1Policy',
     'SawyerBasketballV1Policy',
     'SawyerBoxCloseV1Policy',
     'SawyerButtonPressTopdownV1Policy',
+    'SawyerButtonPressTopdownWallV1Policy',
     'SawyerButtonPressV1Policy',
+    'SawyerButtonPressWallV1Policy',
     'SawyerCoffeeButtonV1Policy',
     'SawyerCoffeePullV1Policy',
     'SawyerCoffeePushV1Policy',

--- a/metaworld/policies/sawyer_assembly_v1_policy.py
+++ b/metaworld/policies/sawyer_assembly_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerAssemblyV1Policy(Policy):
             'hand_pos': obs[:3],
             'wrench_pos': obs[3:6],
             'peg_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_basketball_v1_policy.py
+++ b/metaworld/policies/sawyer_basketball_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerBasketballV1Policy(Policy):
             'hand_pos': obs[:3],
             'ball_pos': obs[3:6],
             'hoop_x': obs[-3],
-            'extra_info': obs[[6, 7, 8, 10, 11]],
+            'unused_info': obs[[6, 7, 8, 10, 11]],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_button_press_topdown_v1_policy.py
+++ b/metaworld/policies/sawyer_button_press_topdown_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerButtonPressTopdownV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'button_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_button_press_topdown_wall_v1_policy.py
+++ b/metaworld/policies/sawyer_button_press_topdown_wall_v1_policy.py
@@ -4,14 +4,14 @@ from metaworld.policies.action import Action
 from metaworld.policies.policy import Policy, assert_fully_parsed, move
 
 
-class SawyerHandlePullV1Policy(Policy):
+class SawyerButtonPressTopdownWallV1Policy(Policy):
 
     @staticmethod
     @assert_fully_parsed
     def _parse_obs(obs):
         return {
             'hand_pos': obs[:3],
-            'handle_pos': obs[3:6],
+            'button_pos': obs[3:6],
             'unused_info': obs[6:],
         }
 
@@ -24,20 +24,16 @@ class SawyerHandlePullV1Policy(Policy):
         })
 
         action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=25.)
-        action['grab_effort'] = 1.
+        action['grab_effort'] = -1.
 
         return action.array
 
     @staticmethod
     def _desired_pos(o_d):
         pos_curr = o_d['hand_pos']
-        pos_button = o_d['handle_pos'] + np.array([.0, -.02, .0])
+        pos_button = o_d['button_pos'] + np.array([.0, -.06, .0])
 
-        if abs(pos_curr[0] - pos_button[0]) > 0.04:
-            return pos_button + np.array([0., 0., 0.2])
-        elif abs(pos_curr[2] - pos_button[2]) > 0.03:
-            return pos_button + np.array([.0, -.1, -.01])
-        elif abs(pos_curr[1] - pos_button[1]) > .01:
-            return np.array([pos_button[0], pos_button[1] + .04, pos_curr[2]])
+        if np.linalg.norm(pos_curr[:2] - pos_button[:2]) > 0.04:
+            return pos_button + np.array([0., 0., 0.1])
         else:
-            return pos_button + np.array([.0, .04, .1])
+            return pos_button

--- a/metaworld/policies/sawyer_button_press_v1_policy.py
+++ b/metaworld/policies/sawyer_button_press_v1_policy.py
@@ -11,7 +11,7 @@ class SawyerButtonPressV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'button_start_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):
@@ -39,7 +39,7 @@ class SawyerButtonPressV1Policy(Policy):
         if not np.all(np.isclose(np.array([hand_x, hand_z]),
                                 np.array([button_initial_x, button_initial_z]),
                                 atol=0.02)):
-            pos_button[1] = pos_curr[1]
+            pos_button[1] = pos_curr[1] - .1
             return pos_button
         # if the hand is aligned with the button, push the button in, by
         # increasing the hand's y position

--- a/metaworld/policies/sawyer_button_press_wall_v1_policy.py
+++ b/metaworld/policies/sawyer_button_press_wall_v1_policy.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+from metaworld.policies.action import Action
+from metaworld.policies.policy import Policy, move
+
+
+class SawyerButtonPressWallV1Policy(Policy):
+
+    @staticmethod
+    def _parse_obs(obs):
+        return {
+            'hand_pos': obs[:3],
+            'button_pos': obs[3:6],
+            'unused_info': obs[6:],
+        }
+
+    def get_action(self, obs):
+        o_d = self._parse_obs(obs)
+
+        action = Action({
+            'delta_pos': np.arange(3),
+            'grab_effort': 3
+        })
+
+        action['delta_pos'] = move(o_d['hand_pos'], to_xyz=self._desired_pos(o_d), p=15.)
+        action['grab_effort'] = self._grab_effort(o_d)
+
+        return action.array
+
+    @staticmethod
+    def _desired_pos(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_button = o_d['button_pos'] + np.array([.0, .0, .04])
+
+        if abs(pos_curr[0] - pos_button[0]) > 0.02:
+            return np.array([pos_button[0], pos_curr[1], .3])
+        elif pos_button[1] - pos_curr[1] > 0.09:
+            return np.array([pos_button[0], pos_button[1], .3])
+        elif abs(pos_curr[2] - pos_button[2]) > 0.02:
+            return pos_button + np.array([.0, -.05, .0])
+        else:
+            return pos_button + np.array([.0, -.02, .0])
+
+    @staticmethod
+    def _grab_effort(o_d):
+        pos_curr = o_d['hand_pos']
+        pos_button = o_d['button_pos'] + np.array([.0, .0, .04])
+
+        if abs(pos_curr[0] - pos_button[0]) > 0.02 or \
+                pos_button[1] - pos_curr[1] > 0.09 or \
+                abs(pos_curr[2] - pos_button[2]) > 0.02:
+            return 1.
+        else:
+            return -1.

--- a/metaworld/policies/sawyer_coffee_button_v1_policy.py
+++ b/metaworld/policies/sawyer_coffee_button_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerCoffeeButtonV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'mug_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_coffee_pull_v1_policy.py
+++ b/metaworld/policies/sawyer_coffee_pull_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerCoffeePullV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'mug_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_coffee_push_v1_policy.py
+++ b/metaworld/policies/sawyer_coffee_push_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerCoffeePushV1Policy(Policy):
             'hand_pos': obs[:3],
             'mug_pos': obs[3:6],
             'goal_xy': obs[9:11],
-            'extra_info': obs[[6, 7, 8, 11]],
+            'unused_info': obs[[6, 7, 8, 11]],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_disassemble_v1_policy.py
+++ b/metaworld/policies/sawyer_disassemble_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerDisassembleV1Policy(Policy):
             'hand_pos': obs[:3],
             'wrench_pos': obs[3:6],
             'peg_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_door_close_v1_policy.py
+++ b/metaworld/policies/sawyer_door_close_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerDoorCloseV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'door_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_door_lock_v1_policy.py
+++ b/metaworld/policies/sawyer_door_lock_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerDoorLockV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'lock_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_door_open_v1_policy.py
+++ b/metaworld/policies/sawyer_door_open_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerDoorOpenV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'door_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_door_unlock_v1_policy.py
+++ b/metaworld/policies/sawyer_door_unlock_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerDoorUnlockV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'lock_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_drawer_close_v1_policy.py
+++ b/metaworld/policies/sawyer_drawer_close_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerDrawerCloseV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'drwr_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_drawer_open_v1_policy.py
+++ b/metaworld/policies/sawyer_drawer_open_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerDrawerOpenV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'drwr_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_faucet_close_v1_policy.py
+++ b/metaworld/policies/sawyer_faucet_close_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerFaucetCloseV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'faucet_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_faucet_open_v1_policy.py
+++ b/metaworld/policies/sawyer_faucet_open_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerFaucetOpenV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'faucet_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_hand_insert_policy.py
+++ b/metaworld/policies/sawyer_hand_insert_policy.py
@@ -13,7 +13,7 @@ class SawyerHandInsertPolicy(Policy):
             'hand_pos': obs[:3],
             'obj_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_handle_press_side_v2_policy.py
+++ b/metaworld/policies/sawyer_handle_press_side_v2_policy.py
@@ -12,7 +12,7 @@ class SawyerHandlePressSideV2Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'handle_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_handle_press_v1_policy.py
+++ b/metaworld/policies/sawyer_handle_press_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerHandlePressV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'handle_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_handle_pull_side_v1_policy.py
+++ b/metaworld/policies/sawyer_handle_pull_side_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerHandlePullSideV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'handle_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_lever_pull_v2_policy.py
+++ b/metaworld/policies/sawyer_lever_pull_v2_policy.py
@@ -12,7 +12,7 @@ class SawyerLeverPullV2Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'lever_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_peg_insertion_side_v2_policy.py
+++ b/metaworld/policies/sawyer_peg_insertion_side_v2_policy.py
@@ -13,7 +13,7 @@ class SawyerPegInsertionSideV2Policy(Policy):
             'hand_pos': obs[:3],
             'peg_pos': obs[3:6],
             'hole_y': obs[-2],
-            'extra_info': obs[[6, 7, 8, 9, 11]],
+            'unused_info': obs[[6, 7, 8, 9, 11]],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_peg_unplug_side_v1_policy.py
+++ b/metaworld/policies/sawyer_peg_unplug_side_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerPegUnplugSideV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'peg_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_pick_out_of_hole_v1_policy.py
+++ b/metaworld/policies/sawyer_pick_out_of_hole_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerPickOutOfHoleV1Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_pick_place_v2_policy.py
+++ b/metaworld/policies/sawyer_pick_place_v2_policy.py
@@ -13,7 +13,7 @@ class SawyerPickPlaceV2Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_pick_place_wall_v2_policy.py
+++ b/metaworld/policies/sawyer_pick_place_wall_v2_policy.py
@@ -13,7 +13,7 @@ class SawyerPickPlaceWallV2Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_plate_slide_back_side_v2_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_back_side_v2_policy.py
@@ -12,7 +12,7 @@ class SawyerPlateSlideBackSideV2Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_plate_slide_back_v1_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_back_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerPlateSlideBackV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_plate_slide_side_v1_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_side_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerPlateSlideSideV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_plate_slide_v1_policy.py
+++ b/metaworld/policies/sawyer_plate_slide_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerPlateSlideV1Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'shelf_x': obs[-3],
-            'extra_info': obs[[6, 7, 8, 10, 11]],
+            'unused_info': obs[[6, 7, 8, 10, 11]],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_push_back_v1_policy.py
+++ b/metaworld/policies/sawyer_push_back_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerPushBackV1Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_push_v2_policy.py
+++ b/metaworld/policies/sawyer_push_v2_policy.py
@@ -13,7 +13,7 @@ class SawyerPushV2Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_push_wall_v2_policy.py
+++ b/metaworld/policies/sawyer_push_wall_v2_policy.py
@@ -13,7 +13,7 @@ class SawyerPushWallV2Policy(Policy):
             'hand_pos': obs[:3],
             'obj_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_reach_v2_policy.py
+++ b/metaworld/policies/sawyer_reach_v2_policy.py
@@ -13,7 +13,7 @@ class SawyerReachV2Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_reach_wall_v2_policy.py
+++ b/metaworld/policies/sawyer_reach_wall_v2_policy.py
@@ -12,7 +12,7 @@ class SawyerReachWallV2Policy(Policy):
             'hand_pos': obs[:3],
             'puck_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_shelf_place_v1_policy.py
+++ b/metaworld/policies/sawyer_shelf_place_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerShelfPlaceV1Policy(Policy):
             'hand_pos': obs[:3],
             'block_pos': obs[3:6],
             'shelf_x': obs[-3],
-            'extra_info': obs[[6, 7, 8, 10, 11]],
+            'unused_info': obs[[6, 7, 8, 10, 11]],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_soccer_v1_policy.py
+++ b/metaworld/policies/sawyer_soccer_v1_policy.py
@@ -13,7 +13,7 @@ class SawyerSoccerV1Policy(Policy):
             'hand_pos': obs[:3],
             'ball_pos': obs[3:6],
             'goal_pos': obs[9:],
-            'extra_info': obs[6:9],
+            'unused_info': obs[6:9],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_sweep_into_v1_policy.py
+++ b/metaworld/policies/sawyer_sweep_into_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerSweepIntoV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'cube_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_sweep_v1_policy.py
+++ b/metaworld/policies/sawyer_sweep_v1_policy.py
@@ -12,7 +12,7 @@ class SawyerSweepV1Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'cube_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_window_close_v2_policy.py
+++ b/metaworld/policies/sawyer_window_close_v2_policy.py
@@ -12,7 +12,7 @@ class SawyerWindowCloseV2Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'wndw_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_window_open_v2_policy.py
+++ b/metaworld/policies/sawyer_window_open_v2_policy.py
@@ -12,7 +12,7 @@ class SawyerWindowOpenV2Policy(Policy):
         return {
             'hand_pos': obs[:3],
             'wndw_pos': obs[3:6],
-            'extra_info': obs[6:],
+            'unused_info': obs[6:],
         }
 
     def get_action(self, obs):

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
@@ -6,18 +6,22 @@ from tests.metaworld.envs.mujoco.sawyer_xyz.utils import trajectory_summary
 
 
 test_cases_old_nonoise = [
-    # This should contain configs where a V2 policy is compatible with a V1 env.
+    # This should contain configs where a V2 policy is running in a V1 env.
     # name, policy, action noise pct, success rate
     ['handle-press-side-v1', SawyerHandlePressSideV2Policy(), .0, .05],
+    ['lever-pull-v1', SawyerLeverPullV2Policy(), .0, .0],
+    ['peg-insert-side-v1', SawyerPegInsertionSideV2Policy(), .0, .0],
     ['plate-slide-back-side-v1', SawyerPlateSlideBackSideV2Policy(), .0, 1.],
     ['window-open-v1', SawyerWindowOpenV2Policy(), .0, 0.85],
     ['window-close-v1', SawyerWindowCloseV2Policy(), .0, 0.37],
 ]
 
 test_cases_old_noisy = [
-    # This should contain configs where a V2 policy is compatible with a V1 env.
+    # This should contain configs where a V2 policy is running in a V1 env.
     # name, policy, action noise pct, success rate
     ['handle-press-side-v1', SawyerHandlePressSideV2Policy(), .1, .77],
+    ['lever-pull-v1', SawyerLeverPullV2Policy(), .1, .0],
+    ['peg-insert-side-v1', SawyerPegInsertionSideV2Policy(), .1, .0],
     ['plate-slide-back-side-v1', SawyerPlateSlideBackSideV2Policy(), .1, 0.30],
     ['window-open-v1', SawyerWindowOpenV2Policy(), .1, 0.81],
     ['window-close-v1', SawyerWindowCloseV2Policy(), .1, 0.37],
@@ -29,7 +33,9 @@ test_cases_latest_nonoise = [
     ['basketball-v1', SawyerBasketballV1Policy(), .0, .98],
     ['box-close-v1', SawyerBoxCloseV1Policy(), .0, .85],
     ['button-press-topdown-v1', SawyerButtonPressTopdownV1Policy(), .0, 1.],
-    ['button-press-v1', SawyerButtonPressV1Policy(), .0, .93],
+    ['button-press-topdown-wall-v1', SawyerButtonPressTopdownWallV1Policy(), .0, 1.],
+    ['button-press-v1', SawyerButtonPressV1Policy(), .0, 1.],
+    ['button-press-wall-v1', SawyerButtonPressWallV1Policy(), .0, 1.],
     ['coffee-button-v1', SawyerCoffeeButtonV1Policy(), .0, 1.],
     ['coffee-pull-v1', SawyerCoffeePullV1Policy(), .0, .96],
     ['coffee-push-v1', SawyerCoffeePushV1Policy(), .0, .93],
@@ -77,7 +83,9 @@ test_cases_latest_noisy = [
     ['basketball-v1', SawyerBasketballV1Policy(), .1, .97],
     ['box-close-v1', SawyerBoxCloseV1Policy(), .1, .85],
     ['button-press-topdown-v1', SawyerButtonPressTopdownV1Policy(), .1, .98],
-    ['button-press-v1', SawyerButtonPressV1Policy(), 0., .94],
+    ['button-press-topdown-wall-v1', SawyerButtonPressTopdownWallV1Policy(), .1, .99],
+    ['button-press-v1', SawyerButtonPressV1Policy(), .1, .98],
+    ['button-press-wall-v1', SawyerButtonPressWallV1Policy(), .1, .95],
     ['coffee-button-v1', SawyerCoffeeButtonV1Policy(), .1, .99],
     ['coffee-pull-v1', SawyerCoffeePullV1Policy(), .1, .95],
     ['coffee-push-v1', SawyerCoffeePushV1Policy(), .1, .88],


### PR DESCRIPTION
I also reordered/re-worked the imports in the env folder's `__init__` and used `import *` in `env_dict.py` rather than rewriting all of the imports again. Everything is now alphabetical