### PR TITLE
Implement correct seeding for the set of tasks

### DIFF
--- a/metaworld/__init__.py
+++ b/metaworld/__init__.py
@@ -90,9 +90,9 @@ def _make_tasks(classes, args_kwargs, kwargs_override, seed=0):
         kwargs = args['kwargs'].copy()
         del kwargs['task_id']
         env._set_task_inner(**kwargs)
-        for rank in range(_N_GOALS):
+        env.seed(seed)
+        for _ in range(_N_GOALS):
             env.reset()
-            env.seed(rank)
             rand_vecs.append(env._last_rand_vec)
         unique_task_rand_vecs = np.unique(np.array(rand_vecs), axis=0)
         assert unique_task_rand_vecs.shape[0] == _N_GOALS

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -299,7 +299,7 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
             assert self._last_rand_vec is not None
             return self._last_rand_vec
         else:
-            rand_vec = np.random.uniform(
+            rand_vec = self.np_random.uniform(
                 self._random_reset_space.low,
                 self._random_reset_space.high,
                 size=self._random_reset_space.low.size)


### PR DESCRIPTION
Achieve the behavior in this [issue](https://github.com/rlworkgroup/metaworld/issues/147).
This allows reproducibility, making benchmark generate same set of tasks if seed passed to it is same. The environment also uses self.np_random instead of uncontrolled np.random