### PR TITLE
New reward function for drawer open

### DIFF
--- a/metaworld/envs/assets_v2/objects/assets/drawer.xml
+++ b/metaworld/envs/assets_v2/objects/assets/drawer.xml
@@ -10,7 +10,7 @@
             <body name="drawer_link" pos="0 -0.01 0.006">
                 <joint type="slide" range="-0.16 0" axis="0 1 0" name="goal_slidey" pos="0 0 0" damping="2"/>
                 <geom material="drawer_beige" mesh="drawer"/>
-                <geom material="drawer_white" mesh="drawerhandle" pos="0 -0.114 0"/>
+                <geom material="drawer_white" mesh="drawerhandle" pos="0 -0.114 0" name="objGeom"/>
                 <geom class="drawer_col" pos="0 -0.082 0.008" size="0.1 0.008 0.052" type="box" mass=".04"/>
                 <geom class="drawer_col" pos="0 0.082 0.008" size="0.1 0.008 0.052" type="box" mass=".04"/>
                 <geom class="drawer_col" pos="-0.092 0 0.008" size="0.008 0.074 0.052" type="box" mass=".04"/>

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_drawer_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_drawer_open_v2.py
@@ -1,6 +1,7 @@
 import numpy as np
 from gym.spaces import Box
 
+from metaworld.envs import reward_utils
 from metaworld.envs.asset_path_utils import full_v2_path_for
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_xyz_env import SawyerXYZEnv, _assert_task_is_set
 
@@ -31,7 +32,7 @@ class SawyerDrawerOpenEnvV2(SawyerXYZEnv):
         goal_low = self.hand_low
         goal_high = self.hand_high
 
-        self.max_path_length = 150
+        self.max_path_length = 500
 
         self._random_reset_space = Box(
             np.array(obj_low),
@@ -49,23 +50,42 @@ class SawyerDrawerOpenEnvV2(SawyerXYZEnv):
     @_assert_task_is_set
     def step(self, action):
         ob = super().step(action)
-        reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+        obj = ob[4:7]
+
+        (
+            reward,
+            gripper_error,
+            gripped,
+            handle_error,
+            caging_reward,
+            opening_reward
+        ) = self.compute_reward(action, ob)
+
         info = {
-            'reachDist': reachDist,
-            'goalDist': pullDist,
-            'epRew': reward,
-            'pickRew': None,
-            'success': float(pullDist <= 0.03),
+            'success': float(handle_error <= 0.03),
+            'near_object': float(gripper_error <= 0.03),
+            'grasp_success': float(gripped > 0),
+            'grasp_reward': caging_reward,
+            'in_place_reward': opening_reward,
+            'obj_to_target': handle_error,
+            'unscaled_reward': reward,
         }
 
+        self.curr_path_length += 1
         return ob, reward, False, info
 
+    def _get_id_main_object(self):
+        return self.unwrapped.model.geom_name2id('objGeom')
+
     def _get_pos_objects(self):
-        return self.get_body_com('drawer_link') + np.array([.0, -.16, .05])
+        return self.get_body_com('drawer_link') + np.array([.0, -.16, .0])
+
+    def _get_quat_objects(self):
+        return self.sim.data.get_body_xquat('drawer_link')
 
     def reset_model(self):
         self._reset_hand()
+        self.prev_obs = self._get_curr_obs_combined_no_goal()
 
         # Compute nightstand position
         self.obj_init_pos = self._get_state_rand_vec() if self.random_init \
@@ -81,39 +101,48 @@ class SawyerDrawerOpenEnvV2(SawyerXYZEnv):
 
     def _reset_hand(self):
         super()._reset_hand()
-        self.reachCompleted = False
+        self.init_tcp = self.tcp_center
+        self.init_left_pad = self.get_body_com('leftpad')
+        self.init_right_pad = self.get_body_com('rightpad')
 
-    def compute_reward(self, actions, obs):
-        del actions
+    def compute_reward(self, action, obs):
+        gripper = obs[:3]
+        handle = obs[4:7]
 
-        objPos = obs[3:6]
-        rightFinger, leftFinger = self._get_site_pos('rightEndEffector'), self._get_site_pos('leftEndEffector')
-        fingerCOM  =  (rightFinger + leftFinger)/2
-        pullGoal = self._target_pos
-        pullDist = np.abs(objPos[1] - pullGoal[1])
-        reachDist = np.linalg.norm(objPos - fingerCOM)
-        reachRew = -reachDist
+        handle_error = np.linalg.norm(handle - self._target_pos)
 
-        self.reachCompleted = reachDist < 0.05
+        reward_for_opening = reward_utils.tolerance(
+            handle_error,
+            bounds=(0, 0.02),
+            margin=self.maxDist,
+            sigmoid='long_tail'
+        )
 
-        def pullReward():
-            c1 = 1000
-            c2 = 0.01
-            c3 = 0.001
+        handle_pos_init = self._target_pos + np.array([.0, self.maxDist, .0])
+        # Emphasize XY error so that gripper is able to drop down and cage
+        # handle without running into it. By doing this, we are assuming
+        # that the reward in the Z direction is small enough that the agent
+        # will be willing to explore raising a finger above the handle, hook it,
+        # and drop back down to re-gain Z reward
+        scale = np.array([3., 3., 1.])
+        gripper_error = (handle - gripper) * scale
+        gripper_error_init = (handle_pos_init - self.init_tcp) * scale
 
-            if self.reachCompleted:
-                pullRew = 1000 * (self.maxDist - pullDist) + c1 * (np.exp(-(pullDist ** 2) / c2) + np.exp(-(pullDist ** 2) / c3))
-                pullRew = max(pullRew,0)
-                return pullRew
-            else:
-                return 0
+        reward_for_caging = reward_utils.tolerance(
+            np.linalg.norm(gripper_error),
+            bounds=(0, 0.01),
+            margin=np.linalg.norm(gripper_error_init),
+            sigmoid='long_tail'
+        )
 
-            pullRew = max(pullRew,0)
+        reward = reward_for_caging + reward_for_opening
+        reward *= 5.0
 
-            return pullRew
-
-
-        pullRew = pullReward()
-        reward = reachRew + pullRew
-
-        return [reward, reachDist, pullDist]
+        return (
+            reward,
+            np.linalg.norm(handle - gripper),
+            obs[3],
+            handle_error,
+            reward_for_caging,
+            reward_for_opening
+        )

--- a/metaworld/policies/sawyer_drawer_open_v2_policy.py
+++ b/metaworld/policies/sawyer_drawer_open_v2_policy.py
@@ -11,8 +11,9 @@ class SawyerDrawerOpenV2Policy(Policy):
     def _parse_obs(obs):
         return {
             'hand_pos': obs[:3],
-            'drwr_pos': obs[3:6],
-            'unused_info': obs[6:],
+            'gripper': obs[3],
+            'drwr_pos': obs[4:7],
+            'unused_info': obs[7:],
         }
 
     def get_action(self, obs):


### PR DESCRIPTION
I based this on commit 0699efd8def2483760516babdb2064ba9feea745 since it looks like some stuff was accidentally committed after that without a PR.

## Scripted policy reward & return

![drawer-open-v2-noise- 0 1,0 1,0 1,0 1 _rewards_returns](https://user-images.githubusercontent.com/17186559/98761249-aa0f5780-239a-11eb-9c93-08d24f12a90f.jpg)
Note that the reward could be fine-tuned to get rid of the humps/plateaus in the reward plot (for example by tracking leftpad position rather than gripper COM, or by using hamacher product of `XY<=thresh && Z` rather than my scaling factor hack), but we shouldn't have to do that. A high-entropy policy should explore past those and find it can achieve even higher reward.

Another option would be to scale the caging reward differently from the drawer-opening reward. For example `2 * caging + 8 * drawer_opening` rather than equal weighting.

Let me know if I need to implement any of this.

## Tensorboard
https://tensorboard.dev/experiment/1uKNBxnWQOydrEimYGxC2A/

### Video of failed seed:
https://drive.google.com/file/d/1IE6U1dd3ANePnzkKN5u2qaT7sOFI3ltX/view?usp=sharing
I think what's happening here is that the agent is super focused on getting the gripper's center-of-mass on top of the handle. So focused, in fact, that it is unable to use one of the fingers to pull on the handle