### PR TITLE
Make peg insert pp high density

### DIFF
--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_insertion_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_insertion_side_v2.py
@@ -171,7 +171,8 @@ class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
                                                      object_reach_radius=object_reach_radius,
                                                      obj_radius=obj_radius,
                                                      pad_success_margin=pad_success_margin,
-                                                     x_z_margin=x_z_margin)
+                                                     x_z_margin=x_z_margin,
+                                                     high_density=True)
         if tcp_to_obj < 0.08 and (tcp_opened > 0) and (obj[2] - 0.01 > self.obj_init_pos[2]):
             object_grasped = 1.
         in_place_and_object_grasped = reward_utils.hamacher_product(object_grasped,
@@ -180,6 +181,9 @@ class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
 
         if tcp_to_obj < 0.08 and (tcp_opened > 0) and (obj[2] - 0.01 > self.obj_init_pos[2]):
             reward += 1. + 5 * in_place
+
+        if obj_to_target <= 0.07:
+            reward = 10.
 
         return [reward, tcp_to_obj, tcp_opened, obj_to_target, object_grasped, in_place, collision_boxes, ip_orig]
 

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_place_v2.py
@@ -202,6 +202,7 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         gripping = gripper_closed if caging > 0.97 else 0.
         caging_and_gripping = reward_utils.hamacher_product(caging,
                                                             gripping)
+        caging_and_gripping = (caging_and_gripping + caging) / 2
         return caging_and_gripping
 
     def compute_reward(self, action, obs):


### PR DESCRIPTION
    Make peg insertion and pick place high density
    
    They were previously low density, however the initial new
    mt10 runs revealed that grasps weren't able to completed with the
    low density function and upon reruning peg insert with high density
    it worked.