### PR TITLE
Safely handle mujoco exceptions (reward=0, obs=last stable)

### DIFF
--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_assembly_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_assembly_peg.py
@@ -51,7 +51,6 @@ class SawyerNutAssemblyEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist, _, success = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'pickRew': pickRew,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_basketball.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_basketball.py
@@ -52,7 +52,6 @@ class SawyerBasketballEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pickRew, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': placingDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_bin_picking.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_bin_picking.py
@@ -57,7 +57,6 @@ class SawyerBinPickingEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_box_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_box_close.py
@@ -48,7 +48,6 @@ class SawyerBoxCloseEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'pickRew': pickRew,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press.py
@@ -43,7 +43,6 @@ class SawyerButtonPressEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pressDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press_topdown.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press_topdown.py
@@ -45,7 +45,6 @@ class SawyerButtonPressTopdownEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pressDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press_topdown_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press_topdown_wall.py
@@ -45,7 +45,6 @@ class SawyerButtonPressTopdownWallEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pressDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press_wall.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_button_press_wall.py
@@ -46,7 +46,6 @@ class SawyerButtonPressWallEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pressDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_coffee_button.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_coffee_button.py
@@ -48,7 +48,6 @@ class SawyerCoffeeButtonEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pushDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_coffee_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_coffee_pull.py
@@ -45,7 +45,6 @@ class SawyerCoffeePullEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_coffee_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_coffee_push.py
@@ -46,7 +46,6 @@ class SawyerCoffeePushEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pushDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_dial_turn.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_dial_turn.py
@@ -44,7 +44,6 @@ class SawyerDialTurnEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_disassemble_peg.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_disassemble_peg.py
@@ -48,7 +48,6 @@ class SawyerNutDisassembleEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist, success = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'pickRew': pickRew,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_door.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_door.py
@@ -49,7 +49,6 @@ class SawyerDoorEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pullDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_door_lock.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_door_lock.py
@@ -45,7 +45,6 @@ class SawyerDoorLockEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_drawer_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_drawer_close.py
@@ -44,7 +44,6 @@ class SawyerDrawerCloseEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pullDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_drawer_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_drawer_open.py
@@ -44,7 +44,6 @@ class SawyerDrawerOpenEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pullDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_faucet_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_faucet_close.py
@@ -44,7 +44,6 @@ class SawyerFaucetCloseEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
         info = {
             'reachDist': reachDist,
             'goalDist': pullDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_faucet_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_faucet_open.py
@@ -43,7 +43,6 @@ class SawyerFaucetOpenEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_hammer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_hammer.py
@@ -43,7 +43,6 @@ class SawyerHammerEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, _, screwDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_hand_insert.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_hand_insert.py
@@ -45,7 +45,6 @@ class SawyerHandInsertEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_press.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_press.py
@@ -44,7 +44,6 @@ class SawyerHandlePressEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_press_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_press_side.py
@@ -44,7 +44,6 @@ class SawyerHandlePressSideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_pull.py
@@ -44,7 +44,6 @@ class SawyerHandlePullEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_pull_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_handle_pull_side.py
@@ -44,7 +44,6 @@ class SawyerHandlePullSideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pressDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_lever_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_lever_pull.py
@@ -45,7 +45,6 @@ class SawyerLeverPullEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_peg_insertion_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_peg_insertion_side.py
@@ -54,7 +54,6 @@ class SawyerPegInsertionSideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_peg_unplug_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_peg_unplug_side.py
@@ -47,7 +47,6 @@ class SawyerPegUnplugSideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide.py
@@ -46,7 +46,6 @@ class SawyerPlateSlideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide_back.py
@@ -46,7 +46,6 @@ class SawyerPlateSlideBackEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide_back_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide_back_side.py
@@ -46,7 +46,6 @@ class SawyerPlateSlideBackSideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide_side.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_plate_slide_side.py
@@ -46,7 +46,6 @@ class SawyerPlateSlideSideEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_push_back.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_push_back.py
@@ -45,7 +45,6 @@ class SawyerPushBackEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_shelf_place.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_shelf_place.py
@@ -54,7 +54,6 @@ class SawyerShelfPlaceEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_soccer.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_soccer.py
@@ -45,7 +45,6 @@ class SawyerSoccerEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_stick_pull.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_stick_pull.py
@@ -51,7 +51,6 @@ class SawyerStickPullEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, pullDist, _ = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_stick_push.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_stick_push.py
@@ -48,7 +48,6 @@ class SawyerStickPushEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, _, reachDist, pickRew, _, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_sweep.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_sweep.py
@@ -49,7 +49,6 @@ class SawyerSweepEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_sweep_into_goal.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_sweep_into_goal.py
@@ -46,7 +46,6 @@ class SawyerSweepIntoGoalEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pushDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_window_close.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_window_close.py
@@ -50,7 +50,6 @@ class SawyerWindowCloseEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pickrew, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_window_open.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v1/sawyer_window_open.py
@@ -50,7 +50,6 @@ class SawyerWindowOpenEnv(SawyerXYZEnv):
     def step(self, action):
         ob = super().step(action)
         reward, reachDist, pickrew, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
 
         info = {
             'reachDist': reachDist,

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_assembly_peg_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_assembly_peg_v2.py
@@ -44,16 +44,14 @@ class SawyerNutAssemblyEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_assembly_peg.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-
+    def evaluate_state(self, obs, action):
         (
             reward,
             reward_grab,
             reward_ready,
             reward_success,
             success
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(success),
@@ -65,8 +63,7 @@ class SawyerNutAssemblyEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_basketball_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_basketball_v2.py
@@ -49,9 +49,8 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_basketball.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        obj = ob[4:7]
+    def evaluate_state(self, obs, action):
+        obj = obs[4:7]
 
         (
             reward,
@@ -60,7 +59,7 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
             obj_to_target,
             grasp_reward,
             in_place_reward
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= self.TARGET_RADIUS),
@@ -75,8 +74,7 @@ class SawyerBasketballEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_id_main_object(self):
         return self.unwrapped.model.geom_name2id('objGeom')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_bin_picking_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_bin_picking_v2.py
@@ -68,9 +68,8 @@ class SawyerBinPickingEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_bin_picking.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        obj = ob[4:7]
+    def evaluate_state(self, obs, action):
+        obj = obs[4:7]
 
         (
             reward,
@@ -79,7 +78,7 @@ class SawyerBinPickingEnvV2(SawyerXYZEnv):
             obj_to_target,
             grasp_reward,
             in_place_reward
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.05),
@@ -95,8 +94,7 @@ class SawyerBinPickingEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_box_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_box_close_v2.py
@@ -46,16 +46,14 @@ class SawyerBoxCloseEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_box.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-
+    def evaluate_state(self, obs, action):
         (
             reward,
             reward_grab,
             reward_ready,
             reward_success,
             success
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(success),
@@ -67,8 +65,7 @@ class SawyerBoxCloseEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_topdown_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_topdown_v2.py
@@ -43,8 +43,7 @@ class SawyerButtonPressTopdownEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_button_press_topdown.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -52,7 +51,7 @@ class SawyerButtonPressTopdownEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -64,8 +63,7 @@ class SawyerButtonPressTopdownEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_topdown_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_topdown_wall_v2.py
@@ -43,8 +43,7 @@ class SawyerButtonPressTopdownWallEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_button_press_topdown_wall.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -52,7 +51,7 @@ class SawyerButtonPressTopdownWallEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -64,8 +63,7 @@ class SawyerButtonPressTopdownWallEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_v2.py
@@ -41,8 +41,7 @@ class SawyerButtonPressEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_button_press.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -50,7 +49,7 @@ class SawyerButtonPressEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -62,8 +61,7 @@ class SawyerButtonPressEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_button_press_wall_v2.py
@@ -45,8 +45,7 @@ class SawyerButtonPressWallEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_button_press_wall.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -54,7 +53,7 @@ class SawyerButtonPressWallEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -66,8 +65,7 @@ class SawyerButtonPressWallEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_coffee_button_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_coffee_button_v2.py
@@ -48,8 +48,7 @@ class SawyerCoffeeButtonEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_coffee.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -57,7 +56,7 @@ class SawyerCoffeeButtonEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -69,8 +68,7 @@ class SawyerCoffeeButtonEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_coffee_pull_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_coffee_pull_v2.py
@@ -45,8 +45,7 @@ class SawyerCoffeePullEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_coffee.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place = self.compute_reward(action, obs)
         success = float(obj_to_target <= 0.07)
         near_object = float(tcp_to_obj <= 0.03)
@@ -62,9 +61,8 @@ class SawyerCoffeePullEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
 
         }
-        self.curr_path_length += 1
 
-        return obs, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_coffee_push_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_coffee_push_v2.py
@@ -45,8 +45,7 @@ class SawyerCoffeePushEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_coffee.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place = self.compute_reward(
             action, obs)
         success = float(obj_to_target <= 0.07)
@@ -63,9 +62,8 @@ class SawyerCoffeePushEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
 
         }
-        self.curr_path_length += 1
 
-        return obs, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_dial_turn_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_dial_turn_v2.py
@@ -43,15 +43,13 @@ class SawyerDialTurnEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_dial.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         (reward,
          tcp_to_obj,
          _,
          target_to_obj,
          object_grasped,
          in_place) = self.compute_reward(action, obs)
-        self.curr_path_length += 1
 
         info = {
             'success': float(target_to_obj <= self.TARGET_RADIUS),
@@ -63,7 +61,7 @@ class SawyerDialTurnEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         dial_center = self.get_body_com('dial').copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_disassemble_peg_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_disassemble_peg_v2.py
@@ -47,8 +47,7 @@ class SawyerNutDisassembleEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_assembly_peg.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
 
         (
             reward,
@@ -56,7 +55,7 @@ class SawyerNutDisassembleEnvV2(SawyerXYZEnv):
             reward_ready,
             reward_success,
             success
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(success),
@@ -68,8 +67,7 @@ class SawyerNutDisassembleEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_close_v2.py
@@ -46,10 +46,8 @@ class SawyerDoorCloseEnvV2(SawyerDoorEnvV2):
         return self._get_obs()
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = SawyerXYZEnv.step(self, action)
+    def evaluate_state(self, obs, action):
         reward, obj_to_target, in_place = self.compute_reward(action, obs)
-        self.curr_path_length += 1
         info = {
             'obj_to_target': obj_to_target,
             'in_place_reward': in_place,
@@ -59,7 +57,7 @@ class SawyerDoorCloseEnvV2(SawyerDoorEnvV2):
             'grasp_reward': 1.,
             'unscaled_reward': reward,
         }
-        return obs, reward, False, info
+        return reward, info
 
     def compute_reward(self, actions, obs):
         _TARGET_RADIUS = 0.05

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_lock_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_lock_v2.py
@@ -45,8 +45,7 @@ class SawyerDoorLockEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_door_lock.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -54,7 +53,7 @@ class SawyerDoorLockEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -66,8 +65,7 @@ class SawyerDoorLockEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_unlock_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_unlock_v2.py
@@ -43,8 +43,7 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_door_lock.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -52,7 +51,7 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
             obj_to_target,
             near_button,
             button_pressed
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.02),
@@ -64,8 +63,7 @@ class SawyerDoorUnlockEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_door_v2.py
@@ -48,16 +48,15 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_door_pull.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             reward_grab,
             reward_ready,
             reward_success,
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
-        success = float(abs(ob[4] - self._target_pos[0]) <= 0.08)
+        success = float(abs(obs[4] - self._target_pos[0]) <= 0.08)
 
         info = {
             'success': success,
@@ -69,8 +68,11 @@ class SawyerDoorEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
+
+    @property
+    def _target_site_config(self):
+        return []
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('handle').copy()

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_drawer_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_drawer_close_v2.py
@@ -47,15 +47,13 @@ class SawyerDrawerCloseEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_drawer.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         (reward,
         tcp_to_obj,
         _,
         target_to_obj,
         object_grasped,
         in_place) = self.compute_reward(action, obs)
-        self.curr_path_length += 1
 
         info = {
             'success': float(target_to_obj <= self.TARGET_RADIUS + 0.015),
@@ -67,7 +65,7 @@ class SawyerDrawerCloseEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.get_body_com('drawer_link') + np.array([.0, -.16, .05])

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_drawer_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_drawer_open_v2.py
@@ -48,10 +48,7 @@ class SawyerDrawerOpenEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_drawer.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        obj = ob[4:7]
-
+    def evaluate_state(self, obs, action):
         (
             reward,
             gripper_error,
@@ -59,7 +56,7 @@ class SawyerDrawerOpenEnvV2(SawyerXYZEnv):
             handle_error,
             caging_reward,
             opening_reward
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(handle_error <= 0.03),
@@ -71,8 +68,7 @@ class SawyerDrawerOpenEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_id_main_object(self):
         return self.unwrapped.model.geom_name2id('objGeom')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_faucet_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_faucet_close_v2.py
@@ -43,10 +43,8 @@ class SawyerFaucetCloseEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_faucet.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
+        reward, reachDist, pullDist = self.compute_reward(action, obs)
         info = {
             'reachDist': reachDist,
             'goalDist': pullDist,
@@ -55,7 +53,7 @@ class SawyerFaucetCloseEnvV2(SawyerXYZEnv):
             'success': float(pullDist <= 0.05),
         }
 
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_faucet_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_faucet_open_v2.py
@@ -43,10 +43,8 @@ class SawyerFaucetOpenEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_faucet.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
+        reward, reachDist, pullDist = self.compute_reward(action, obs)
         info = {
             'reachDist': reachDist,
             'goalDist': pullDist,
@@ -55,7 +53,7 @@ class SawyerFaucetOpenEnvV2(SawyerXYZEnv):
             'success': float(pullDist <= 0.05),
         }
 
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_hammer_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_hammer_v2.py
@@ -41,16 +41,14 @@ class SawyerHammerEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_hammer.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-
+    def evaluate_state(self, obs, action):
         (
             reward,
             reward_grab,
             reward_ready,
             reward_success,
             success
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(success),
@@ -62,8 +60,7 @@ class SawyerHammerEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_id_main_object(self):
         return self.unwrapped.model.geom_name2id('HammerHandle')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_hand_insert_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_hand_insert_v2.py
@@ -45,9 +45,8 @@ class SawyerHandInsertEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_table_with_hole.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        obj = ob[4:7]
+    def evaluate_state(self, obs, action):
+        obj = obs[4:7]
 
         (
             reward,
@@ -56,7 +55,7 @@ class SawyerHandInsertEnvV2(SawyerXYZEnv):
             obj_to_target,
             grasp_reward,
             in_place_reward
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(obj_to_target <= 0.05),
@@ -72,8 +71,7 @@ class SawyerHandInsertEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _get_id_main_object(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_press_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_press_side_v2.py
@@ -3,7 +3,7 @@ from gym.spaces import Box
 
 from metaworld.envs import reward_utils
 from metaworld.envs.asset_path_utils import full_v2_path_for
-from metaworld.envs.mujoco.sawyer_xyz.sawyer_xyz_env import SawyerXYZEnv
+from metaworld.envs.mujoco.sawyer_xyz.sawyer_xyz_env import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerHandlePressSideEnvV2(SawyerXYZEnv):
@@ -53,18 +53,14 @@ class SawyerHandlePressSideEnvV2(SawyerXYZEnv):
     def model_name(self):
         return full_v2_path_for('sawyer_xyz/sawyer_handle_press_sideways.xml')
 
-    def step(self, action):
-        self.set_xyz_action(action[:3])
-        self.do_simulation([action[-1], -action[-1]])
-        # The marker seems to get reset every time you do a simulation
-        obs = self._get_obs()
+    @_assert_task_is_set
+    def evaluate_state(self, obs, action):
         (reward,
         tcp_to_obj,
         _,
         target_to_obj,
         object_grasped,
         in_place) = self.compute_reward(action, obs)
-        self.curr_path_length += 1
 
         info = {
             'success': float(target_to_obj <= self.TARGET_RADIUS),
@@ -76,7 +72,7 @@ class SawyerHandlePressSideEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self._get_site_pos('handleStart')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_press_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_press_v2.py
@@ -43,9 +43,7 @@ class SawyerHandlePressEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_handle_press.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
         (reward,
         tcp_to_obj,
         _,
@@ -63,7 +61,7 @@ class SawyerHandlePressEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_pull_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_pull_side_v2.py
@@ -43,8 +43,7 @@ class SawyerHandlePullSideEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_handle_press_sideways.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
 
         (
@@ -69,8 +68,7 @@ class SawyerHandlePullSideEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):
@@ -125,7 +123,6 @@ class SawyerHandlePullSideEnvV2(SawyerXYZEnv):
         )
 
         object_grasped = self._gripper_caging_reward(
-            self,
             action,
             obj,
             pad_success_thresh=0.06,

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_pull_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_handle_pull_v2.py
@@ -42,8 +42,7 @@ class SawyerHandlePullEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_handle_press.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
 
         (reward,
@@ -67,8 +66,7 @@ class SawyerHandlePullEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     @property
     def _target_site_config(self):
@@ -116,7 +114,6 @@ class SawyerHandlePullEnvV2(SawyerXYZEnv):
         )
 
         object_grasped = self._gripper_caging_reward(
-            self,
             action,
             obj,
             pad_success_thresh=0.05,

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_lever_pull_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_lever_pull_v2.py
@@ -57,8 +57,7 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_lever_pull.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
 
         (
             reward,
@@ -66,7 +65,7 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
             ready_to_lift,
             lever_error,
             lever_engagement
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         info = {
             'success': float(lever_error <= np.pi / 24),
@@ -78,8 +77,7 @@ class SawyerLeverPullEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_id_main_object(self):
         return self.unwrapped.model.geom_name2id('objGeom')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_insertion_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_insertion_side_v2.py
@@ -67,10 +67,7 @@ class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_peg_insertion_side.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-
-        obs = self._get_obs()
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
 
         reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place_reward, collision_box_front, ip_orig= (
@@ -89,8 +86,7 @@ class SawyerPegInsertionSideEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self._get_site_pos('pegGrasp')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_unplug_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_unplug_side_v2.py
@@ -40,10 +40,8 @@ class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_peg_unplug_side.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
+        reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, obs)
 
         info = {
             'reachDist': reachDist,
@@ -53,7 +51,7 @@ class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
             'success': float(placingDist <= 0.07)
         }
 
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self._get_site_pos('pegEnd')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_out_of_hole_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_out_of_hole_v2.py
@@ -46,10 +46,8 @@ class SawyerPickOutOfHoleEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_pick_out_of_hole.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        reward, reachDist, pickRew, placingDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
+        reward, reachDist, pickRew, placingDist = self.compute_reward(action, obs)
 
         info = {
             'reachDist': reachDist,
@@ -59,7 +57,7 @@ class SawyerPickOutOfHoleEnvV2(SawyerXYZEnv):
             'success': float(placingDist <= 0.08)
         }
 
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.get_body_com('obj')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_place_v2.py
@@ -60,11 +60,10 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_pick_place_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        obj = ob[4:7]
+    def evaluate_state(self, obs, action):
+        obj = obs[4:7]
 
-        reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place_reward = self.compute_reward(action, ob)
+        reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place_reward = self.compute_reward(action, obs)
         success = float(obj_to_target <= 0.07)
         near_object = float(tcp_to_obj <= 0.03)
         grasp_success = float(self.touching_main_object and (tcp_open > 0) and (obj[2] - 0.02 > self.obj_init_pos[2]))
@@ -78,8 +77,7 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     @property
     def _get_id_main_object(self):
@@ -111,8 +109,6 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
         self._target_pos = self.goal.copy()
         self.obj_init_pos = self.fix_extreme_obj_pos(self.init_config['obj_init_pos'])
         self.obj_init_angle = self.init_config['obj_init_angle']
-        self.objHeight = self.get_body_com('obj')[2]
-        self.heightTarget = self.objHeight + self.liftThresh
 
         if self.random_init:
             goal_pos = self._get_state_rand_vec()
@@ -127,12 +123,6 @@ class SawyerPickPlaceEnvV2(SawyerXYZEnv):
             self.init_right_pad = self.get_body_com('rightpad')
 
         self._set_obj_xyz(self.obj_init_pos)
-        self.maxPlacingDist = np.linalg.norm(
-            np.array([self.obj_init_pos[0],
-                      self.obj_init_pos[1],
-                      self.heightTarget]) -
-            np.array(self._target_pos)) + self.heightTarget
-        self.target_reward = 1000*self.maxPlacingDist + 1000*2
         self.num_resets += 1
 
         return self._get_obs()

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_place_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_pick_place_wall_v2.py
@@ -60,8 +60,7 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_pick_place_wall_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
         (
             reward,
@@ -86,8 +85,7 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward
         }
 
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('objGeom')
@@ -116,8 +114,6 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
         self._target_pos = self.goal.copy()
         self.obj_init_pos = self.adjust_initObjPos(self.init_config['obj_init_pos'])
         self.obj_init_angle = self.init_config['obj_init_angle']
-        self.objHeight = self.data.get_geom_xpos('objGeom')[2]
-        self.heightTarget = self.objHeight + self.liftThresh
 
         if self.random_init:
             goal_pos = self._get_state_rand_vec()
@@ -129,14 +125,6 @@ class SawyerPickPlaceWallEnvV2(SawyerXYZEnv):
             self.obj_init_pos = goal_pos[:3]
 
         self._set_obj_xyz(self.obj_init_pos)
-        self.maxplacing_dist = np.linalg.norm(
-            np.array([
-                self.obj_init_pos[0],
-                self.obj_init_pos[1],
-                self.heightTarget
-            ]) - np.array(self._target_pos)
-        ) + self.heightTarget
-        self.target_reward = 1000 * self.maxplacing_dist + 1000 * 2
         self.num_resets += 1
 
         return self._get_obs()

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_back_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_back_side_v2.py
@@ -55,10 +55,8 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_plate_slide_sideway.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        reward, reachDist, pullDist = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
+        reward, reachDist, pullDist = self.compute_reward(action, obs)
 
         info = {
             'reachDist': reachDist,
@@ -68,7 +66,7 @@ class SawyerPlateSlideBackSideEnvV2(SawyerXYZEnv):
             'success': float(pullDist <= 0.07)
         }
 
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('puck')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_back_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_back_v2.py
@@ -45,8 +45,7 @@ class SawyerPlateSlideBackEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_plate_slide.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -54,7 +53,7 @@ class SawyerPlateSlideBackEnvV2(SawyerXYZEnv):
             obj_to_target,
             object_grasped,
             in_place
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         success = float(obj_to_target <= 0.07)
         near_object = float(tcp_to_obj <= 0.03)
@@ -67,8 +66,7 @@ class SawyerPlateSlideBackEnvV2(SawyerXYZEnv):
             'obj_to_target': obj_to_target,
             'unscaled_reward': reward
         }
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('puck')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_side_v2.py
@@ -45,8 +45,7 @@ class SawyerPlateSlideSideEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_plate_slide_sideway.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -54,7 +53,7 @@ class SawyerPlateSlideSideEnvV2(SawyerXYZEnv):
             obj_to_target,
             object_grasped,
             in_place
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         success = float(obj_to_target <= 0.07)
         near_object = float(tcp_to_obj <= 0.03)
@@ -67,8 +66,7 @@ class SawyerPlateSlideSideEnvV2(SawyerXYZEnv):
             'obj_to_target': obj_to_target,
             'unscaled_reward': reward
         }
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('puck')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_plate_slide_v2.py
@@ -48,8 +48,7 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_plate_slide.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -57,7 +56,7 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
             obj_to_target,
             object_grasped,
             in_place
-        ) = self.compute_reward(action, ob)
+        ) = self.compute_reward(action, obs)
 
         success = float(obj_to_target <= 0.07)
         near_object = float(tcp_to_obj <= 0.03)
@@ -70,8 +69,7 @@ class SawyerPlateSlideEnvV2(SawyerXYZEnv):
             'obj_to_target': obj_to_target,
             'unscaled_reward': reward
         }
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('puck')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_push_back_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_push_back_v2.py
@@ -48,8 +48,7 @@ class SawyerPushBackEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_push_back_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
         (
             reward,
@@ -73,8 +72,7 @@ class SawyerPushBackEnvV2(SawyerXYZEnv):
             'obj_to_target': target_to_obj,
             'unscaled_reward': reward,
         }
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('objGeom')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_push_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_push_v2.py
@@ -65,8 +65,7 @@ class SawyerPushEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_push_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
 
         (
@@ -92,8 +91,7 @@ class SawyerPushEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     def _get_quat_objects(self):
         return Rotation.from_matrix(

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_push_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_push_wall_v2.py
@@ -67,8 +67,7 @@ class SawyerPushWallEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_push_wall_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
         (
             reward,
@@ -92,8 +91,7 @@ class SawyerPushWallEnvV2(SawyerXYZEnv):
             'obj_to_target': obj_to_target,
             'unscaled_reward': reward
         }
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.data.get_geom_xpos('objGeom')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_reach_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_reach_v2.py
@@ -59,10 +59,9 @@ class SawyerReachEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_reach_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
 
-        reward, reach_dist, in_place = self.compute_reward(action, ob)
+        reward, reach_dist, in_place = self.compute_reward(action, obs)
         success = float(reach_dist <= 0.05)
 
         info = {
@@ -75,8 +74,7 @@ class SawyerReachEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.get_body_com('obj')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_reach_wall_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_reach_wall_v2.py
@@ -59,10 +59,9 @@ class SawyerReachWallEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_reach_wall_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
+    def evaluate_state(self, obs, action):
 
-        reward, tcp_to_object, in_place = self.compute_reward(action, ob)
+        reward, tcp_to_object, in_place = self.compute_reward(action, obs)
         success = float(tcp_to_object <= 0.05)
 
         info = {
@@ -75,8 +74,7 @@ class SawyerReachWallEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        self.curr_path_length += 1
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.get_body_com('obj')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_shelf_place_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_shelf_place_v2.py
@@ -46,8 +46,7 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_shelf_placing.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
         reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place = self.compute_reward(action, obs)
         success = float(obj_to_target <= 0.07)
@@ -64,9 +63,8 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
 
         }
-        self.curr_path_length += 1
 
-        return obs, reward, False, info
+        return reward, info
 
 
     def _get_pos_objects(self):
@@ -92,8 +90,6 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
         self._target_pos = self.sim.model.site_pos[self.model.site_name2id('goal')] + self.sim.model.body_pos[self.model.body_name2id('shelf')]
         self.obj_init_pos = self.adjust_initObjPos(self.init_config['obj_init_pos'])
         self.obj_init_angle = self.init_config['obj_init_angle']
-        self.objHeight = self.get_body_com('obj')[2]
-        self.heightTarget = self.objHeight + self.liftThresh
 
         if self.random_init:
             goal_pos = self._get_state_rand_vec()
@@ -105,8 +101,6 @@ class SawyerShelfPlaceEnvV2(SawyerXYZEnv):
             self._target_pos = self.sim.model.site_pos[self.model.site_name2id('goal')] + self.sim.model.body_pos[self.model.body_name2id('shelf')]
 
         self._set_obj_xyz(self.obj_init_pos)
-        self.maxPlacingDist = np.linalg.norm(np.array([self.obj_init_pos[0], self.obj_init_pos[1], self.heightTarget]) - np.array(self._target_pos)) + self.heightTarget
-        self.target_reward = 1000*self.maxPlacingDist + 1000*2
         self.num_resets += 1
 
         return self._get_obs()

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_soccer_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_soccer_v2.py
@@ -49,8 +49,7 @@ class SawyerSoccerEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_soccer.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
         (
             reward,
@@ -60,7 +59,6 @@ class SawyerSoccerEnvV2(SawyerXYZEnv):
             object_grasped,
             in_place
         ) = self.compute_reward(action, obs)
-        self.curr_path_length += 1
 
         success = float(target_to_obj <= 0.07)
         near_object = float(tcp_to_obj <= 0.03)
@@ -75,7 +73,7 @@ class SawyerSoccerEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self.get_body_com('soccer_ball')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_stick_pull_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_stick_pull_v2.py
@@ -44,10 +44,8 @@ class SawyerStickPullEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_stick_obj.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        ob = super().step(action)
-        reward, _, reachDist, pickRew, _, pullDist, _ = self.compute_reward(action, ob)
-        self.curr_path_length += 1
+    def evaluate_state(self, obs, action):
+        reward, _, reachDist, pickRew, _, pullDist, _ = self.compute_reward(action, obs)
 
         info = {
             'reachDist': reachDist,
@@ -57,7 +55,7 @@ class SawyerStickPullEnvV2(SawyerXYZEnv):
             'success': float(pullDist <= 0.08 and reachDist <= 0.05)
         }
 
-        return ob, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return np.hstack((

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_stick_push_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_stick_push_v2.py
@@ -45,8 +45,7 @@ class SawyerStickPushEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_stick_obj.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         stick = obs[4:7]
         container = obs[11:14]
         reward, tcp_to_obj, tcp_open, container_to_target, grasp_reward, stick_in_place = self.compute_reward(action, obs)
@@ -64,9 +63,8 @@ class SawyerStickPushEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
 
         }
-        self.curr_path_length += 1
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return np.hstack((
@@ -105,8 +103,6 @@ class SawyerStickPushEnvV2(SawyerXYZEnv):
         self._reset_hand()
         self.stick_init_pos = self.init_config['stick_init_pos']
         self._target_pos = np.array([0.4, 0.6, self.stick_init_pos[-1]])
-        self.stickHeight = self.get_body_com('stick').copy()[2]
-        self.heightTarget = self.stickHeight + self.liftThresh
 
         if self.random_init:
             goal_pos = self._get_state_rand_vec()
@@ -118,8 +114,6 @@ class SawyerStickPushEnvV2(SawyerXYZEnv):
         self._set_stick_xyz(self.stick_init_pos)
         self._set_obj_xyz(self.obj_init_qpos)
         self.obj_init_pos = self.get_body_com('object').copy()
-        self.maxPlaceDist = np.linalg.norm(np.array([self.obj_init_pos[0], self.obj_init_pos[1], self.heightTarget]) - np.array(self.stick_init_pos)) + self.heightTarget
-        self.maxPushDist = np.linalg.norm(self.obj_init_pos[:2] - self._target_pos[:2])
 
         return self._get_obs()
 

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_sweep_into_goal_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_sweep_into_goal_v2.py
@@ -47,8 +47,7 @@ class SawyerSweepIntoGoalEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_table_with_hole.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         obj = obs[4:7]
         (
             reward,
@@ -70,8 +69,7 @@ class SawyerSweepIntoGoalEnvV2(SawyerXYZEnv):
             'obj_to_target': target_to_obj,
             'unscaled_reward': reward,
         }
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     def _get_quat_objects(self):
         return Rotation.from_matrix(

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_sweep_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_sweep_v2.py
@@ -50,8 +50,7 @@ class SawyerSweepEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_sweep_v2.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         (
             reward,
             tcp_to_obj,
@@ -72,8 +71,7 @@ class SawyerSweepEnvV2(SawyerXYZEnv):
             'obj_to_target': target_to_obj,
             'unscaled_reward': reward,
         }
-        self.curr_path_length += 1
-        return obs, reward, False, info
+        return reward, info
 
     def _get_quat_objects(self):
         return self.data.get_body_xquat('obj')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_window_close_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_window_close_v2.py
@@ -61,15 +61,13 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_window_horizontal.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         (reward,
         tcp_to_obj,
         _,
         target_to_obj,
         object_grasped,
         in_place) = self.compute_reward(action, obs)
-        self.curr_path_length += 1
 
         info = {
             'success': float(target_to_obj <= self.TARGET_RADIUS),
@@ -81,7 +79,7 @@ class SawyerWindowCloseEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self._get_site_pos('handleCloseStart')

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_window_open_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_window_open_v2.py
@@ -57,15 +57,13 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
         return full_v2_path_for('sawyer_xyz/sawyer_window_horizontal.xml')
 
     @_assert_task_is_set
-    def step(self, action):
-        obs = super().step(action)
+    def evaluate_state(self, obs, action):
         (reward,
         tcp_to_obj,
         _,
         target_to_obj,
         object_grasped,
         in_place) = self.compute_reward(action, obs)
-        self.curr_path_length += 1
 
         info = {
             'success': float(target_to_obj <= self.TARGET_RADIUS),
@@ -77,7 +75,7 @@ class SawyerWindowOpenEnvV2(SawyerXYZEnv):
             'unscaled_reward': reward,
         }
 
-        return obs, reward, False, info
+        return reward, info
 
     def _get_pos_objects(self):
         return self._get_site_pos('handleOpenStart')

--- a/metaworld/policies/sawyer_peg_insertion_side_v2_policy.py
+++ b/metaworld/policies/sawyer_peg_insertion_side_v2_policy.py
@@ -16,7 +16,7 @@ class SawyerPegInsertionSideV2Policy(Policy):
             'peg_rot': obs[7:11],
             'goal_pos': obs[-3:],
             'unused_info_curr_obs': obs[11:18],
-            'prev_obs': obs[18:36]
+            '_prev_obs': obs[18:36]
         }
 
     def get_action(self, obs):

--- a/metaworld/policies/sawyer_pick_place_v2_policy.py
+++ b/metaworld/policies/sawyer_pick_place_v2_policy.py
@@ -16,7 +16,7 @@ class SawyerPickPlaceV2Policy(Policy):
             'puck_rot': obs[7:11],
             'goal_pos': obs[-3:],
             'unused_info_curr_obs': obs[11:18],
-            'prev_obs':obs[18:36]
+            '_prev_obs':obs[18:36]
         }
 
     def get_action(self, obs):


### PR DESCRIPTION
Yes there are 95 changed files, but the only significant ones are `mujoco_env.py` and `sawyer_xyz_env.py`

For the record, I'm not fond of what `sawyer_xyz_env` has become in the past 6 months. It really tries to do too much at once -- it handles basic API for v1 envs *and* v2 envs, while also housing lots of utility-type functions. It wouldn't be so bad except that the inheritance structure is all over the place. I'd prefer more composability, but I think that's something we can leave for visual metaworld (which is already headed in that direction).

Just don't look too closely and it won't bother you. This is research after all, not SWE