### PR TITLE
New Peg Unplug Side Reward

### DIFF
--- a/metaworld/envs/assets_v2/objects/assets/plug.xml
+++ b/metaworld/envs/assets_v2/objects/assets/plug.xml
@@ -5,10 +5,15 @@
       <geom material="plug_black" pos="0.06 0 0" size="0.04" type="sphere"/>
       <geom material="plug_black" euler="0 1.57 0" pos="0.025 0.0 -0.0" size="0.04 0.035" type="cylinder"/>
 
-      <geom class="plug_col" pos="-0.035 0 0" size="0.036 0.021 0.021" type="box" mass=".001"/>
+      <!-- <geom class="plug_col" pos="-0.035 0 0" size="0.036 0.021 0.021" type="box" mass=".001"/>
       <geom class="plug_col" euler="0 1.57 0" pos="-0.013 0 0" size="0.045  0.007" type="cylinder" mass=".001"/>
       <geom class="plug_col" pos="0.06 0 0" size="0.04" type="sphere" mass=".001"/>
-      <geom class="plug_col" euler="0 1.57 0" pos="0.025 0.0 -0.0" size="0.04 0.035" type="cylinder" mass=".001"/>
+      <geom class="plug_col" euler="0 1.57 0" pos="0.025 0.0 -0.0" size="0.038 0.038 0.035" type="box" mass=".001"/>
+      -->
+      <geom class="plug_col" pos="-0.035 0 0" size="0.03" type="sphere" mass=".05" rgba="0.8 0 0 1"/>
+      <geom class="plug_col" euler="0 1.57 0" pos="-0.013 0 0" size="0.045  0.007" type="cylinder" mass=".01" rgba="0.8 0 0 1"/>
+      <geom class="plug_col" pos="0.06 0 0" size="0.04" type="sphere" mass=".01" rgba="0.8 0 0 1"/>
+      <geom class="plug_col" euler="0 1.57 0" pos="0.025 0.0 -0.0" size="0.038 0.038 0.035" type="box" mass=".01"/>
 
       <site name="pegHead" pos="-0.04 0 0" size="0.005" rgba="0.8 0 0 1"/>
       <site name="pegEnd" pos="0.04 0 0" size="0.005" rgba="0.8 0 0 1"/>

--- a/metaworld/envs/assets_v2/sawyer_xyz/sawyer_peg_unplug_side.xml
+++ b/metaworld/envs/assets_v2/sawyer_xyz/sawyer_peg_unplug_side.xml
@@ -9,7 +9,10 @@
       <body name="plug1" pos="-.252 .6 .131">
         <joint type="free"/>
         <include file="../objects/assets/plug.xml"/>
-
+        <!-- <geom pos="-0.035 0 0" size="0.036 0.021 0.021" type="box" mass=".001" rgba="0.8 0 0 1"/>
+        <geom euler="0 1.57 0" pos="-0.013 0 0" size="0.045  0.007" type="cylinder" mass=".001" rgba="0.8 0 0 1"/>
+        <geom pos="0.06 0 0" size="0.04" type="sphere" mass=".001" rgba="0.8 0 0 1"/>
+        <geom euler="0 1.57 0" pos="0.025 0.0 -0.0" size="0.038 0.038 0.035" type="box" mass=".001"/> -->
       </body>
 
       <body name="box" pos="-.3 .6 0">

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_unplug_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_unplug_side_v2.py
@@ -1,12 +1,12 @@
 import numpy as np
-from gym.spaces import  Box
+from gym.spaces import Box
 
+from metaworld.envs import reward_utils
 from metaworld.envs.asset_path_utils import full_v2_path_for
 from metaworld.envs.mujoco.sawyer_xyz.sawyer_xyz_env import SawyerXYZEnv, _assert_task_is_set
 
 
 class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
-
     def __init__(self):
         hand_low = (-0.5, 0.40, 0.05)
         hand_high = (0.5, 1, 0.5)
@@ -41,20 +41,30 @@ class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
 
     @_assert_task_is_set
     def evaluate_state(self, obs, action):
-        reward, _, reachDist, pickRew, _, placingDist = self.compute_reward(action, obs)
+        obj = obs[4:7]
+
+        reward, tcp_to_obj, tcp_open, obj_to_target, grasp_reward, in_place_reward, grasp_success = (
+            self.compute_reward(action, obs))
+        success = float(obj_to_target <= 0.07)
+        near_object = float(tcp_to_obj <= 0.03)
 
         info = {
-            'reachDist': reachDist,
-            'pickRew': pickRew,
-            'epRew': reward,
-            'goalDist': placingDist,
-            'success': float(placingDist <= 0.07)
+            'success': success,
+            'near_object': near_object,
+            'grasp_success': grasp_success,
+            'grasp_reward': grasp_reward,
+            'in_place_reward': in_place_reward,
+            'obj_to_target': obj_to_target,
+            'unscaled_reward': reward,
         }
 
         return reward, info
 
     def _get_pos_objects(self):
         return self._get_site_pos('pegEnd')
+
+    def _get_quat_objects(self):
+        return self.sim.data.get_body_xquat('plug1')
 
     def _set_obj_xyz(self, pos):
         qpos = self.data.qpos.flat.copy()
@@ -76,56 +86,42 @@ class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
 
         self._target_pos = pos_plug + np.array([.2, .0, .0])
 
-        self.objHeight = pos_plug[2]
-        self.heightTarget = self.objHeight + self.liftThresh
-        self.maxPlacingDist = np.linalg.norm(self._target_pos - self.obj_init_pos)
-        self.target_reward = 1000*self.maxPlacingDist + 1000*2
-
         return self._get_obs()
 
-    def compute_reward(self, actions, obs):
-        objPos = obs[3:6]
+    def compute_reward(self, action, obs):
+        tcp = self.tcp_center
+        obj = obs[4:7]
+        tcp_opened = obs[3]
+        target = self._target_pos
+        tcp_to_obj = np.linalg.norm(obj - tcp)
+        obj_to_target = np.linalg.norm(obj - target)
+        pad_success_margin = 0.05
+        object_reach_radius = 0.01
+        x_z_margin = 0.005
+        obj_radius = 0.015
 
-        rightFinger, leftFinger = self._get_site_pos('rightEndEffector'), self._get_site_pos('leftEndEffector')
-        fingerCOM  =  (rightFinger + leftFinger)/2
+        object_grasped = self._gripper_caging_reward(
+            action,
+            obj,
+            object_reach_radius=object_reach_radius,
+            obj_radius=obj_radius,
+            pad_success_thresh=pad_success_margin,
+            xz_thresh=x_z_margin,
+            desired_gripper_effort=0.8,
+            high_density=True)
+        in_place_margin = np.linalg.norm(self.obj_init_pos - target)
+        in_place = reward_utils.tolerance(
+            obj_to_target,
+            bounds=(0, 0.05),
+            margin=in_place_margin,
+            sigmoid='long_tail',
+        )
+        grasp_success = (tcp_opened > 0.3 and 
+            (obj[0] - self.obj_init_pos[0] > 0.03))
+        reward = object_grasped
+        if obj_to_target <= 0.07:
+            reward = 10.
+        # something is wrong with the peg end in peg unplug.
 
-        placingGoal = self._target_pos
-
-        reachDist = np.linalg.norm(objPos - fingerCOM)
-
-        placingDist = np.linalg.norm(objPos[:-1] - placingGoal[:-1])
-
-
-        def reachReward():
-            reachDistxy = np.linalg.norm(objPos[:-1] - fingerCOM[:-1])
-            zRew = np.linalg.norm(fingerCOM[-1] - self.hand_init_pos[-1])
-
-            if reachDistxy < 0.05:
-                reachRew = -reachDist
-            else:
-                reachRew =  -reachDistxy - 2*zRew
-
-            # incentive to close fingers when reachDist is small
-            if reachDist < 0.05:
-                reachRew = -reachDist + max(actions[-1],0)/50
-            return reachRew, reachDist
-
-        self.reachCompleted = reachDist < 0.05
-
-        def placeReward():
-            c1 = 1000
-            c2 = 0.01
-            c3 = 0.001
-            if self.reachCompleted:
-                placeRew = 1000*(self.maxPlacingDist - placingDist) + c1*(np.exp(-(placingDist**2)/c2) + np.exp(-(placingDist**2)/c3))
-                placeRew = max(placeRew,0)
-                return [placeRew , placingDist]
-            else:
-                return [0 , placingDist]
-
-        reachRew, reachDist = reachReward()
-        placeRew, placingDist = placeReward()
-        assert placeRew >=0
-        reward = reachRew + placeRew
-
-        return [reward, reachRew, reachDist, None, placeRew, placingDist]
+        return reward, tcp_to_obj, tcp_opened, obj_to_target, object_grasped, in_place, float(
+            grasp_success)

--- a/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_unplug_side_v2.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/v2/sawyer_peg_unplug_side_v2.py
@@ -98,7 +98,7 @@ class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
         pad_success_margin = 0.05
         object_reach_radius = 0.01
         x_z_margin = 0.005
-        obj_radius = 0.015
+        obj_radius = 0.025
 
         object_grasped = self._gripper_caging_reward(
             action,
@@ -117,20 +117,17 @@ class SawyerPegUnplugSideEnvV2(SawyerXYZEnv):
             margin=in_place_margin,
             sigmoid='long_tail',
         )
-        grasp_success = (tcp_opened > 0.3 and 
-            (obj[0] - self.obj_init_pos[0] > 0.005))
+        grasp_success = (tcp_opened > 0.5 and 
+            (obj[0] - self.obj_init_pos[0] > 0.015))
+        
+        
         reward = 2 * object_grasped
 
-
-        if grasp_success:
-            reward = 2 * object_grasped + 5 * in_place
+        if grasp_success and tcp_to_obj < 0.035:
+            reward = 1 + 2 * object_grasped + 5 * in_place
 
         if obj_to_target <= 0.05:
             reward = 10.
-        # something is wrong with the peg end in peg unplug.
-
-        print("REWARD: {}, {}, {}".format(reward, object_grasped, in_place))
-        # print(self.obj_init_pos, obj)
 
         return reward, tcp_to_obj, tcp_opened, obj_to_target, object_grasped, in_place, float(
             grasp_success)

--- a/metaworld/policies/sawyer_peg_unplug_side_v2_policy.py
+++ b/metaworld/policies/sawyer_peg_unplug_side_v2_policy.py
@@ -11,8 +11,9 @@ class SawyerPegUnplugSideV2Policy(Policy):
     def _parse_obs(obs):
         return {
             'hand_pos': obs[:3],
-            'peg_pos': obs[3:6],
-            'unused_info': obs[6:],
+            'unused_gripper': obs[3],
+            'peg_pos': obs[4:7],
+            'unused_info': obs[7:],
         }
 
     def get_action(self, obs):

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_scripted_policies.py
@@ -177,7 +177,7 @@ test_cases_latest_noisy = [
     ['peg-insert-side-v2', SawyerPegInsertionSideV2Policy(), .1, .87],
     ['lever-pull-v2', SawyerLeverPullV2Policy(), .1, .90],
     ['peg-unplug-side-v1', SawyerPegUnplugSideV1Policy(), .1, .97],
-    ['peg-unplug-side-v2', SawyerPegUnplugSideV2Policy(), .1, .95],
+    ['peg-unplug-side-v2', SawyerPegUnplugSideV2Policy(), .1, .80],
     ['pick-out-of-hole-v1', SawyerPickOutOfHoleV1Policy(), .1, .89],
     ['pick-out-of-hole-v2', SawyerPickOutOfHoleV2Policy(), .1, .89],
     ['pick-place-v2', SawyerPickPlaceV2Policy(), .1, .83],


### PR DESCRIPTION
New reward function for peg unplug side v2. Includes new grasp success parameter logic, and smooth rewards similar to all other new rewards.

Runs: 3/4 PPO (seeds: 1245, 2364, 9285_2, 6211<-failed seed) 3/3 SAC (seeds: 1374_1, 74542, 87643) 

Tensorboard: https://tensorboard.dev/experiment/mjVUMXn0S5iDKXUacbytxA/