### PR TITLE
Enable MT50 and ML45 constructors to use V2 envs

### DIFF
--- a/metaworld/__init__.py
+++ b/metaworld/__init__.py
@@ -173,14 +173,15 @@ class ML45(Benchmark):
 
     def __init__(self):
         super().__init__()
-        self._train_classes = _env_dict.HARD_MODE_CLS_DICT['train']
-        self._test_classes = _env_dict.HARD_MODE_CLS_DICT['test']
-        train_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['train']
+        self._train_classes = _env_dict.ML45_V2['train']
+        self._test_classes = _env_dict.ML45_V2['test']
+        train_kwargs = _env_dict.ml45_train_args_kwargs
         self._train_tasks = _make_tasks(self._train_classes,
                                         train_kwargs,
                                         _ML_OVERRIDE)
+        test_kwargs = _env_dict.ml45_test_args_kwargs
         self._test_tasks = _make_tasks(self._test_classes,
-                                       _env_dict.HARD_MODE_ARGS_KWARGS['test'],
+                                       test_kwargs,
                                        _ML_OVERRIDE)
 
 
@@ -201,16 +202,9 @@ class MT50(Benchmark):
 
     def __init__(self):
         super().__init__()
-        self._train_classes = _env_dict.HARD_MODE_CLS_DICT['train'].copy()
-        # We're going to modify it, so make a copy
-        train_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['train'].copy()
-        test_kwargs = _env_dict.HARD_MODE_ARGS_KWARGS['test']
-        for (env_name, cls) in _env_dict.HARD_MODE_CLS_DICT['test'].items():
-            assert env_name not in self._train_classes
-            assert env_name not in train_kwargs
-            self._train_classes[env_name] = cls
-            train_kwargs[env_name] = test_kwargs[env_name]
+        self._train_classes = _env_dict.MT50_V2
         self._test_classes = OrderedDict()
+        train_kwargs = _env_dict.MT50_V2_ARGS_KWARGS
         self._train_tasks = _make_tasks(self._train_classes,
                                         train_kwargs,
                                         _MT_OVERRIDE)

--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -368,6 +368,7 @@ for key, env_cls in HARD_MODE_CLS_DICT['train'].items():
 for key, env_cls in HARD_MODE_CLS_DICT['test'].items():
     HARD_MODE_ARGS_KWARGS['test'][key] = _hard_mode_args_kwargs(env_cls, key)
 
+############################## V2 DICTS ##############################
 
 MT10_V2 = OrderedDict((
     ('reach-v2', SawyerReachEnvV2),
@@ -441,3 +442,146 @@ ML1_args_kwargs = {
     })
     for key, _ in ML1_V2['train'].items()
 }
+
+MT50_V2 = OrderedDict((
+    ('assembly-v2', SawyerNutAssemblyEnvV2),
+    ('basketball-v2', SawyerBasketballEnvV2),
+    ('bin-picking-v2', SawyerBinPickingEnvV2),
+    ('box-close-v2', SawyerBoxCloseEnvV2),
+    ('button-press-topdown-v2', SawyerButtonPressTopdownEnvV2),
+    ('button-press-topdown-wall-v2', SawyerButtonPressTopdownWallEnvV2),
+    ('button-press-v2', SawyerButtonPressEnvV2),
+    ('button-press-wall-v2', SawyerButtonPressWallEnvV2),
+    ('coffee-button-v2', SawyerCoffeeButtonEnvV2),
+    ('coffee-pull-v2', SawyerCoffeePullEnvV2),
+    ('coffee-push-v2', SawyerCoffeePushEnvV2),
+    ('dial-turn-v2', SawyerDialTurnEnvV2),
+    ('disassemble-v2', SawyerNutDisassembleEnvV2),
+    ('door-close-v2', SawyerDoorCloseEnvV2),
+    ('door-lock-v2', SawyerDoorLockEnvV2),
+    ('door-open-v2', SawyerDoorEnvV2),
+    ('door-unlock-v2', SawyerDoorUnlockEnvV2),
+    ('hand-insert-v2', SawyerHandInsertEnvV2),
+    ('drawer-close-v2', SawyerDrawerCloseEnvV2),
+    ('drawer-open-v2', SawyerDrawerOpenEnvV2),
+    ('faucet-open-v2', SawyerFaucetOpenEnvV2),
+    ('faucet-close-v2', SawyerFaucetCloseEnvV2),
+    ('hammer-v2', SawyerHammerEnvV2),
+    ('handle-press-side-v2', SawyerHandlePressSideEnvV2),
+    ('handle-press-v2', SawyerHandlePressEnvV2),
+    ('handle-pull-side-v2', SawyerHandlePullSideEnvV2),
+    ('handle-pull-v2', SawyerHandlePullEnvV2),
+    ('lever-pull-v2', SawyerLeverPullEnvV2),
+    ('peg-insert-side-v2', SawyerPegInsertionSideEnvV2),
+    ('pick-place-wall-v2', SawyerPickPlaceWallEnvV2),
+    ('pick-out-of-hole-v2', SawyerPickOutOfHoleEnvV2),
+    ('reach-v2', SawyerReachEnvV2),
+    ('push-back-v2', SawyerPushBackEnvV2),
+    ('push-v2', SawyerPushEnvV2),
+    ('pick-place-v2', SawyerPickPlaceEnvV2),
+    ('plate-slide-v2', SawyerPlateSlideEnvV2),
+    ('plate-slide-side-v2', SawyerPlateSlideSideEnvV2),
+    ('plate-slide-back-v2', SawyerPlateSlideBackEnvV2),
+    ('plate-slide-back-side-v2', SawyerPlateSlideBackSideEnvV2),
+    ('peg-insert-side-v2', SawyerPegInsertionSideEnvV2),
+    ('peg-unplug-side-v2', SawyerPegUnplugSideEnvV2),
+    ('soccer-v2', SawyerSoccerEnvV2),
+    ('stick-push-v2', SawyerStickPushEnvV2),
+    ('stick-pull-v2', SawyerStickPullEnvV2),
+    ('push-wall-v2', SawyerPushWallEnvV2),
+    ('push-v2', SawyerPushEnvV2),
+    ('reach-wall-v2', SawyerReachWallEnvV2),
+    ('reach-v2', SawyerReachEnvV2),
+    ('shelf-place-v2', SawyerShelfPlaceEnvV2),
+    ('sweep-into-v2', SawyerSweepIntoGoalEnvV2),
+    ('sweep-v2', SawyerSweepEnvV2),
+    ('window-open-v2', SawyerWindowOpenEnvV2),
+    ('window-close-v2', SawyerWindowCloseEnvV2),))
+
+
+MT50_V2_ARGS_KWARGS = {
+    key: dict(args=[],
+              kwargs={
+                  'task_id': list(ALL_V2_ENVIRONMENTS.keys()).index(key)
+              })
+    for key, _ in MT50_V2.items()
+}
+
+
+ML45_V2 = OrderedDict((
+    ('train',
+        OrderedDict((
+            ('assembly-v2', SawyerNutAssemblyEnvV2),
+            ('basketball-v2', SawyerBasketballEnvV2),
+            ('button-press-topdown-v2', SawyerButtonPressTopdownEnvV2),
+            ('button-press-topdown-wall-v2', SawyerButtonPressTopdownWallEnvV2),
+            ('button-press-v2', SawyerButtonPressEnvV2),
+            ('button-press-wall-v2', SawyerButtonPressWallEnvV2),
+            ('coffee-button-v2', SawyerCoffeeButtonEnvV2),
+            ('coffee-pull-v2', SawyerCoffeePullEnvV2),
+            ('coffee-push-v2', SawyerCoffeePushEnvV2),
+            ('dial-turn-v2', SawyerDialTurnEnvV2),
+            ('disassemble-v2', SawyerNutDisassembleEnvV2),
+            ('door-close-v2', SawyerDoorCloseEnvV2),
+            ('door-open-v2', SawyerDoorEnvV2),
+            ('drawer-close-v2', SawyerDrawerCloseEnvV2),
+            ('drawer-open-v2', SawyerDrawerOpenEnvV2),
+            ('faucet-open-v2', SawyerFaucetOpenEnvV2),
+            ('faucet-close-v2', SawyerFaucetCloseEnvV2),
+            ('hammer-v2', SawyerHammerEnvV2),
+            ('handle-press-side-v2', SawyerHandlePressSideEnvV2),
+            ('handle-press-v2', SawyerHandlePressEnvV2),
+            ('handle-pull-side-v2', SawyerHandlePullSideEnvV2),
+            ('handle-pull-v2', SawyerHandlePullEnvV2),
+            ('lever-pull-v2', SawyerLeverPullEnvV2),
+            ('peg-insert-side-v2', SawyerPegInsertionSideEnvV2),
+            ('pick-place-wall-v2', SawyerPickPlaceWallEnvV2),
+            ('pick-out-of-hole-v2', SawyerPickOutOfHoleEnvV2),
+            ('reach-v2', SawyerReachEnvV2),
+            ('push-back-v2', SawyerPushBackEnvV2),
+            ('push-v2', SawyerPushEnvV2),
+            ('pick-place-v2', SawyerPickPlaceEnvV2),
+            ('plate-slide-v2', SawyerPlateSlideEnvV2),
+            ('plate-slide-side-v2', SawyerPlateSlideSideEnvV2),
+            ('plate-slide-back-v2', SawyerPlateSlideBackEnvV2),
+            ('plate-slide-back-side-v2', SawyerPlateSlideBackSideEnvV2),
+            ('peg-insert-side-v2', SawyerPegInsertionSideEnvV2),
+            ('peg-unplug-side-v2', SawyerPegUnplugSideEnvV2),
+            ('soccer-v2', SawyerSoccerEnvV2),
+            ('stick-push-v2', SawyerStickPushEnvV2),
+            ('stick-pull-v2', SawyerStickPullEnvV2),
+            ('push-wall-v2', SawyerPushWallEnvV2),
+            ('push-v2', SawyerPushEnvV2),
+            ('reach-wall-v2', SawyerReachWallEnvV2),
+            ('reach-v2', SawyerReachEnvV2),
+            ('shelf-place-v2', SawyerShelfPlaceEnvV2),
+            ('sweep-into-v2', SawyerSweepIntoGoalEnvV2),
+            ('sweep-v2', SawyerSweepEnvV2),
+            ('window-open-v2', SawyerWindowOpenEnvV2),
+            ('window-close-v2', SawyerWindowCloseEnvV2),))
+            ),
+    ('test',
+        OrderedDict((
+            ('bin-picking-v2', SawyerBinPickingEnvV2),
+            ('box-close-v2', SawyerBoxCloseEnvV2),
+            ('hand-insert-v2', SawyerHandInsertEnvV2),
+            ('door-lock-v2', SawyerDoorLockEnvV2),
+            ('door-unlock-v2', SawyerDoorUnlockEnvV2),))
+)))
+
+ml45_train_args_kwargs = {
+    key: dict(args=[], kwargs={
+        'task_id' : list(ALL_V2_ENVIRONMENTS.keys()).index(key),
+    })
+    for key, _ in ML45_V2['train'].items()
+}
+
+ml45_test_args_kwargs = {
+    key: dict(args=[], kwargs={'task_id' : list(ALL_V2_ENVIRONMENTS.keys()).index(key)})
+    for key, _ in ML45_V2['test'].items()
+}
+
+ML45_ARGS_KWARGS = dict(
+    train=ml45_train_args_kwargs,
+    test=ml45_test_args_kwargs,
+)


### PR DESCRIPTION
Master was not using v2 environments in MT50 and ML45. 

env_dict still needs to be cleaned up a bit. 

@ryanjulian @tianheyu927:
Is it imperative that we give people to use the benchmark, and environments, in it's v1 version, from the metaworld package?

If not, I'd like to delete the v1 environments, and any additional code that came with them.