### PR TITLE
Give mt1 envs separate names

### DIFF
--- a/metaworld/__init__.py
+++ b/metaworld/__init__.py
@@ -104,6 +104,8 @@ def _make_tasks(classes, args_kwargs, kwargs_override, mt1=False):
             kwargs.update(kwargs_override)
             if mt1:
                 env_name_modified = f"{env_name}-{i}"
+            else:
+                env_name_modified = env_name
             tasks.append(_encode_task(env_name_modified, kwargs))
     return tasks
 


### PR DESCRIPTION
MT1 environment classes need to have distinct names otherwise users will have to treat their handling of multitask benchmarks such as MT10 and MT50 differently from how they handle MT1 environments.