### PR TITLE
Update setup.py with new version of Mujoco

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 required = [
     # Please keep alphabetized
     'gym>=0.15.4',
-    'mujoco-py<2.1,>=2.0',
+    'mujoco-py<2.2,>=2.1',
     'numpy>=1.18',
 ]
 


### PR DESCRIPTION
The existing Mujoco version dependencies require old (activation-key locked) versions of Mujoco (most of which have expired by now?).

This PR updates `setup.py` with current version (open-source, free) of Mujoco.

Note: Haven't tested things beyond basic imports - probably worth ensuring feature parity with older versions?