### PR TITLE
Add an option to control rand_vec using a seed instead of the task

### DIFF
--- a/metaworld/envs/mujoco/env_dict.py
+++ b/metaworld/envs/mujoco/env_dict.py
@@ -592,6 +592,7 @@ def create_hidden_goal_envs():
             env.reset()
             env._freeze_rand_vec = True
             if seed is not None:
+                env.seed(seed)
                 np.random.set_state(st0)
 
         d['__init__'] = initialize
@@ -622,6 +623,7 @@ def create_observable_goal_envs():
             env.reset()
             env._freeze_rand_vec = True
             if seed is not None:
+                env.seed(seed)
                 np.random.set_state(st0)
 
         d['__init__'] = initialize

--- a/metaworld/envs/mujoco/mujoco_env.py
+++ b/metaworld/envs/mujoco/mujoco_env.py
@@ -58,10 +58,14 @@ class MujocoEnv(gym.Env, abc.ABC):
 
         self._did_see_sim_exception = False
 
-        self.seed()
+        self.np_random, _ = seeding.np_random(None)
 
-    def seed(self, seed=None):
+    def seed(self, seed):
+        assert seed is not None
         self.np_random, seed = seeding.np_random(seed)
+        self.action_space.seed(seed)
+        self.observation_space.seed(seed)
+        self.goal_space.seed(seed)
         return [seed]
 
     @abc.abstractmethod

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -111,6 +111,7 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
         self.mocap_low = np.hstack(mocap_low)
         self.mocap_high = np.hstack(mocap_high)
         self.curr_path_length = 0
+        self.seeded_rand_vec = False
         self._freeze_rand_vec = True
         self._last_rand_vec = None
 
@@ -469,6 +470,13 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
         if self._freeze_rand_vec:
             assert self._last_rand_vec is not None
             return self._last_rand_vec
+        elif self.seeded_rand_vec:
+            rand_vec = self.np_random.uniform(
+                self._random_reset_space.low,
+                self._random_reset_space.high,
+                size=self._random_reset_space.low.size)
+            self._last_rand_vec = rand_vec
+            return rand_vec
         else:
             rand_vec = np.random.uniform(
                 self._random_reset_space.low,

--- a/tests/metaworld/envs/mujoco/sawyer_xyz/test_seeded_rand_vec.py
+++ b/tests/metaworld/envs/mujoco/sawyer_xyz/test_seeded_rand_vec.py
@@ -1,0 +1,29 @@
+import random
+
+import pytest
+import numpy as np
+
+from metaworld.envs import ALL_V2_ENVIRONMENTS_GOAL_OBSERVABLE
+
+
+@pytest.mark.parametrize(
+    'env_name',
+    sorted(ALL_V2_ENVIRONMENTS_GOAL_OBSERVABLE.keys()))
+def test_observations_match(env_name):
+    seed = random.randrange(1000)
+    env1 = ALL_V2_ENVIRONMENTS_GOAL_OBSERVABLE[env_name](seed=seed)
+    env1.seeded_rand_vec = True
+    env2 = ALL_V2_ENVIRONMENTS_GOAL_OBSERVABLE[env_name](seed=seed)
+    env2.seeded_rand_vec = True
+
+    obs1, obs2 = env1.reset(), env2.reset()
+    assert (obs1 == obs2).all()
+
+    for i in range(env1.max_path_length):
+        a = np.random.uniform(low=-1, high=-1, size=4)
+        obs1, r1, done1, _ = env1.step(a)
+        obs2, r2, done2, _ = env2.step(a)
+        assert (obs1 == obs2).all()
+        assert r1 == r2
+        assert not done1
+        assert not done2


### PR DESCRIPTION
Currently when a `Benchmark` is created a set of `rand_vec` are chosen based on the seed passed into the `Benchmark` constructor, and then distributed among the `train_tasks` and `test_tasks`.
From then on, the only randomness in each environment is the initial state derived from those state objects.
However, several users (myself included) would also like to use individual environments with an unlimited number of initial states.
Currently, users achieve this by setting `env._freeze_rand_vec` to `False`, which causes the environment to sample from the global `np.random` state.
Although this results in a deterministic environment when used in Garage, many other RL frameworks do not, or cannot, make the global random state deterministic.

Unfortunately, the semantics of `_freeze_rand_vec` are fairly complicated at this point, both because it's used during `Benchmark` creation as described above and because users (at least Garage users) expect it to result in use of the global `np.random` state.

To address this, this change adds a new field, `seeded_rand_vec`, that allows for the desired behavior.
If you would like to use this feature, please see the [added test](https://github.com/rlworkgroup/metaworld/blob/c3f4849ce7886b906bbb2f93e531354214f6b130/tests/metaworld/envs/mujoco/sawyer_xyz/test_seeded_rand_vec.py).